### PR TITLE
Include return type IDs when tokenizing for TextClassification pipelines

### DIFF
--- a/pipelines/textClassification.go
+++ b/pipelines/textClassification.go
@@ -98,6 +98,7 @@ func NewTextClassificationPipeline(config PipelineConfig[*TextClassificationPipe
 	// tokenizer init
 	pipeline.TokenizerOptions = []tokenizers.EncodeOption{
 		tokenizers.WithReturnAttentionMask(),
+		tokenizers.WithReturnTypeIDs(),
 	}
 	tk, err := loadTokenizer(pipeline.ModelPath)
 	if err != nil {


### PR DESCRIPTION
- This PR addresses https://github.com/knights-analytics/hugot/issues/41
- If a Text Classification pipeline has [token type IDs](https://huggingface.co/docs/transformers/glossary#token-type-ids), the `Preprocess` step will panic since an empty slice of IDs is provided, and the function will attempt to index it.
- This PR will add the token type IDs by default.
