### PR TITLE
change: add session context and make run context aware

### DIFF
--- a/backends/model_gomlx.go
+++ b/backends/model_gomlx.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,12 +10,12 @@ import (
 	"github.com/gomlx/gomlx/backends"
 	"github.com/gomlx/gomlx/pkg/core/graph"
 	"github.com/gomlx/gomlx/pkg/core/tensors"
-	"github.com/gomlx/gomlx/pkg/ml/context"
+	gomlxcontext "github.com/gomlx/gomlx/pkg/ml/context"
 	"github.com/gomlx/onnx-gomlx/onnx"
 	"github.com/gomlx/onnx-gomlx/onnx/parser"
-
 	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/util/fileutil"
+	"golang.org/x/sync/errgroup"
 )
 
 // Default shape buckets for batch size and sequence length.
@@ -27,9 +28,9 @@ var (
 type GoMLXModel struct {
 	Backend         backends.Backend
 	OnnxModel       onnx.Model
-	Ctx             *context.Context // ctx with the model's weights.
-	Exec            *context.Exec    // exec is used to execute the model with a context.
-	Call            func(ctx *context.Context, inputs []*graph.Node) []*graph.Node
+	Ctx             *gomlxcontext.Context // ctx with the model's weights.
+	Exec            *gomlxcontext.Exec    // exec is used to execute the model with a context.
+	Call            func(ctx *gomlxcontext.Context, inputs []*graph.Node) []*graph.Node
 	Destroy         func()
 	BatchBuckets    []int // BatchBuckets defines bucket sizes for batch dimension padding.
 	SequenceBuckets []int // SequenceBuckets defines bucket sizes for sequence length padding.
@@ -57,7 +58,7 @@ func createGoMLXModelBackend(model *Model, options *options.Options) error {
 		outputNames = append(outputNames, v.Name)
 	}
 
-	ctx := context.New()
+	ctx := gomlxcontext.New()
 	// Mark it to reuse variables: it will be an error to create a new variable – for safety.
 	ctx = ctx.Reuse()
 
@@ -82,7 +83,7 @@ func createGoMLXModelBackend(model *Model, options *options.Options) error {
 	}
 
 	// Create model executor.
-	callFunc := func(ctx *context.Context, inputs []*graph.Node) []*graph.Node {
+	callFunc := func(ctx *gomlxcontext.Context, inputs []*graph.Node) []*graph.Node {
 		inputsMap := map[string]*graph.Node{}
 		for i, inputMeta := range model.InputsMeta {
 			inputsMap[inputMeta.Name] = inputs[i]
@@ -90,7 +91,7 @@ func createGoMLXModelBackend(model *Model, options *options.Options) error {
 		return modelParsed.CallGraph(ctx, inputs[0].Graph(), inputsMap, outputNames...)
 	}
 
-	exec, contextErr := context.NewExec(backend, ctx, callFunc)
+	exec, contextErr := gomlxcontext.NewExec(backend, ctx, callFunc)
 	if contextErr != nil {
 		return errors.Join(contextErr, modelParsed.Close())
 	}
@@ -268,13 +269,47 @@ func createInputTensorsGoMLX(batch *PipelineBatch, model *Model, padBatchDimensi
 	return nil
 }
 
-func runGoMLXSessionOnBatch(batch *PipelineBatch, p *BasePipeline) error {
-	// Non-generative models
-	outputTensors, err := p.Model.GoMLXModel.Exec.Exec(batch.InputValues.([]*tensors.Tensor))
-	if err != nil {
-		return err
+func runGoMLXSessionOnBatch(ctx context.Context, batch *PipelineBatch, p *BasePipeline) error {
+	if p.SessionContext == nil {
+		return errors.New("no session context")
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.SessionContext.Done():
+		return p.SessionContext.Err()
+	default:
 	}
 
+	var outputTensors []*tensors.Tensor
+	doneChannel := make(chan bool, 1)
+	eg := errgroup.Group{}
+	eg.Go(func() (err error) {
+		defer func() {
+			// C code does not support context, so cancelling a context and/or session will usually trigger a segfault(panic).
+			// recover this here, so context can be cancelled gracefully and return an error.
+			if r := recover(); r != nil {
+				err = fmt.Errorf("recovered from panic: %v", r)
+			}
+			close(doneChannel)
+		}()
+		var execErr error
+		outputTensors, execErr = p.Model.GoMLXModel.Exec.Exec(batch.InputValues.([]*tensors.Tensor))
+		return errors.Join(execErr, err)
+	})
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.SessionContext.Done():
+		return p.SessionContext.Err()
+	case <-doneChannel:
+		if err := eg.Wait(); err != nil {
+			return err
+		}
+	}
+
+	var err error
 	defer func() {
 		for _, t := range outputTensors {
 			err = errors.Join(t.FinalizeAll())

--- a/backends/model_ort.go
+++ b/backends/model_ort.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	ort "github.com/yalue/onnxruntime_go"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/knights-analytics/hugot/options"
 	"github.com/knights-analytics/hugot/util/fileutil"
@@ -143,6 +144,17 @@ func createORTGenerativeSession(model *Model, options *options.Options) error {
 }
 
 func runGenerativeORTSessionOnBatch(ctx context.Context, batch *PipelineBatch, p *BasePipeline, maxLength int, stopSequences []string, temperature *float64, topP *float64, seed *int, tools []string, guidance *Guidance) (chan SequenceDelta, chan error, error) {
+	if p.SessionContext == nil {
+		return nil, nil, errors.New("no session context")
+	}
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-p.SessionContext.Done():
+		return nil, nil, p.SessionContext.Err()
+	default:
+	}
+
 	session := p.Model.ORTModel.GenerativeSession
 	if session == nil {
 		return nil, nil, errors.New("ORT generative session is not initialized")
@@ -471,13 +483,42 @@ func createInputTensorsORT(batch *PipelineBatch, model *Model) error {
 	return nil
 }
 
-func runORTSessionOnBatch(batch *PipelineBatch, p *BasePipeline) error {
-	var err error
+func runORTSessionOnBatch(ctx context.Context, batch *PipelineBatch, p *BasePipeline) error {
+	if p.SessionContext == nil {
+		return errors.New("no session context")
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.SessionContext.Done():
+		return p.SessionContext.Err()
+	default:
+	}
 
 	outputTensors := make([]ort.Value, len(p.Model.OutputsMeta))
-	errOnnx := p.Model.ORTModel.Session.Run(batch.InputValues.([]ort.Value), outputTensors)
-	if errOnnx != nil {
-		return errOnnx
+	doneChannel := make(chan bool, 1)
+	eg := errgroup.Group{}
+	eg.Go(func() (err error) {
+		defer func() {
+			// C code does not support context, so cancelling a context and/or session will usually trigger a segfault(panic).
+			// recover this here, so context can be cancelled gracefully and return an error.
+			if r := recover(); r != nil {
+				err = fmt.Errorf("recovered from panic: %v", r)
+			}
+			close(doneChannel)
+		}()
+		return errors.Join(err, p.Model.ORTModel.Session.Run(batch.InputValues.([]ort.Value), outputTensors))
+	})
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.SessionContext.Done():
+		return p.SessionContext.Err()
+	case <-doneChannel:
+		if err := eg.Wait(); err != nil {
+			return err
+		}
 	}
 
 	convertedOutput := make([]any, len(outputTensors))
@@ -491,7 +532,7 @@ func runORTSessionOnBatch(batch *PipelineBatch, p *BasePipeline) error {
 	}
 	// store resulting tensors
 	batch.OutputValues = convertedOutput
-	return err
+	return nil
 }
 
 func convertORTInputOutputs(inputOutputs []ort.InputOutputInfo) []InputOutputInfo {

--- a/backends/model_ort_disabled.go
+++ b/backends/model_ort_disabled.go
@@ -22,7 +22,7 @@ func createInputTensorsORT(_ *PipelineBatch, _ *Model) error {
 	return errors.New("ORT is not enabled")
 }
 
-func runORTSessionOnBatch(_ *PipelineBatch, _ *BasePipeline) error {
+func runORTSessionOnBatch(_ context.Context, _ *PipelineBatch, _ *BasePipeline) error {
 	return errors.New("ORT is not enabled")
 }
 

--- a/backends/pipeline.go
+++ b/backends/pipeline.go
@@ -20,6 +20,7 @@ type BasePipeline struct {
 	PipelineTimings *timings
 	PipelineName    string
 	Runtime         string
+	SessionContext  context.Context
 }
 
 type InputOutputInfo struct {
@@ -61,12 +62,12 @@ type PipelineBatchOutput interface {
 
 // Pipeline is the interface that any pipeline must implement.
 type Pipeline interface {
-	GetStatistics() PipelineStatistics         // Get the pipeline running statistics
-	Validate() error                           // Validate the pipeline for correctness
-	GetMetadata() PipelineMetadata             // Return metadata information for the pipeline
-	GetModel() *Model                          // Return the model used by the pipeline
-	IsGenerative() bool                        // Return whether the pipeline is generative
-	Run([]string) (PipelineBatchOutput, error) // Run the pipeline on an input
+	GetStatistics() PipelineStatistics                          // Get the pipeline running statistics
+	Validate() error                                            // Validate the pipeline for correctness
+	GetMetadata() PipelineMetadata                              // Return metadata information for the pipeline
+	GetModel() *Model                                           // Return the model used by the pipeline
+	IsGenerative() bool                                         // Return whether the pipeline is generative
+	Run(context.Context, []string) (PipelineBatchOutput, error) // Run the pipeline on an input
 }
 
 type PipelineStatistics struct {
@@ -189,12 +190,12 @@ func GetNames(info []InputOutputInfo) []string {
 	return names
 }
 
-func RunSessionOnBatch(batch *PipelineBatch, p *BasePipeline) error {
+func RunSessionOnBatch(ctx context.Context, batch *PipelineBatch, p *BasePipeline) error {
 	switch p.Runtime {
 	case "ORT":
-		return runORTSessionOnBatch(batch, p)
+		return runORTSessionOnBatch(ctx, batch, p)
 	case "GO", "XLA":
-		return runGoMLXSessionOnBatch(batch, p)
+		return runGoMLXSessionOnBatch(ctx, batch, p)
 	}
 	return nil
 }
@@ -264,12 +265,13 @@ func CreateTabularTensors(batch *PipelineBatch, model *Model, features [][]float
 	}
 }
 
-func NewBasePipeline[T Pipeline](config PipelineConfig[T], s *options.Options, model *Model) (*BasePipeline, error) {
+func NewBasePipeline[T Pipeline](sessionContext context.Context, config PipelineConfig[T], s *options.Options, model *Model) (*BasePipeline, error) {
 	pipeline := &BasePipeline{}
 	pipeline.Runtime = s.Backend
 	pipeline.PipelineName = config.Name
 	pipeline.Model = model
 	pipeline.PipelineTimings = &timings{}
+	pipeline.SessionContext = sessionContext
 	return pipeline, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/knights-analytics/hugot
 go 1.25.0
 
 require (
-	github.com/daulet/tokenizers v1.26.0
+	github.com/daulet/tokenizers v1.27.0
 	github.com/gomlx/go-huggingface v0.3.5-0.20260327162928-af20e4f3e7b5
 	github.com/gomlx/gomlx v0.27.2
 	github.com/gomlx/onnx-gomlx v0.4.2-0.20260327164137-4e2832549fc1
@@ -12,6 +12,7 @@ require (
 	github.com/viant/afs v1.30.0
 	github.com/yalue/onnxruntime_go v1.27.0
 	golang.org/x/image v0.38.0
+	golang.org/x/sync v0.20.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
-github.com/daulet/tokenizers v1.26.0 h1:lNaydh8kbwpEzm8CGqrGyIWAamgRDhU8puewo5ygs7g=
-github.com/daulet/tokenizers v1.26.0/go.mod h1:YjFY1o1HGMyWkQgbXJDghhvke/yFDp2vGdIO2hYs4MQ=
+github.com/daulet/tokenizers v1.27.0 h1:MmFYAEDFz69s/nNQfHg59DWqHz3v94m99kEZ/JbL+s4=
+github.com/daulet/tokenizers v1.27.0/go.mod h1:YjFY1o1HGMyWkQgbXJDghhvke/yFDp2vGdIO2hYs4MQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -102,6 +102,8 @@ golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 h1:jiDhWWeC7jfWqR9c/uplMOqJ0
 golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90/go.mod h1:xE1HEv6b+1SCZ5/uscMRjUBKtIxworgEcEi+/n9NQDQ=
 golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
 golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=

--- a/hugot.go
+++ b/hugot.go
@@ -1,6 +1,7 @@
 package hugot
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -25,9 +26,11 @@ type Session struct {
 	models                          map[string]*backends.Model
 	options                         *options.Options
 	environmentDestroy              func() error
+	sessionContext                  context.Context
+	cancelSessionContext            context.CancelFunc
 }
 
-func newSession(backend string, opts ...options.WithOption) (*Session, error) {
+func newSession(ctx context.Context, backend string, opts ...options.WithOption) (*Session, error) {
 	parsedOptions := options.Defaults()
 	parsedOptions.Backend = backend
 	// Collect options into a struct, so they can be applied in the correct order later
@@ -40,6 +43,8 @@ func newSession(backend string, opts ...options.WithOption) (*Session, error) {
 			return nil, err
 		}
 	}
+
+	sessionContext, cancelSessionContext := context.WithCancel(ctx)
 
 	session := &Session{
 		featureExtractionPipelines:      map[string]*pipelines.FeatureExtractionPipeline{},
@@ -57,6 +62,8 @@ func newSession(backend string, opts ...options.WithOption) (*Session, error) {
 		environmentDestroy: func() error {
 			return nil
 		},
+		sessionContext:       sessionContext,
+		cancelSessionContext: cancelSessionContext,
 	}
 
 	return session, nil
@@ -164,7 +171,7 @@ func NewPipeline[T backends.Pipeline](s *Session, pipelineConfig backends.Pipeli
 		s.models[modelID] = model
 	}
 
-	pipeline, name, err = InitializePipeline(pipeline, pipelineConfig, s.options, model)
+	pipeline, name, err = initializePipeline(s.sessionContext, pipeline, pipelineConfig, s.options, model)
 	if err != nil {
 		return pipeline, err
 	}
@@ -196,14 +203,14 @@ func NewPipeline[T backends.Pipeline](s *Session, pipelineConfig backends.Pipeli
 	return pipeline, nil
 }
 
-func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.PipelineConfig[T], options *options.Options, model *backends.Model) (T, string, error) {
+func initializePipeline[T backends.Pipeline](sessionContext context.Context, p T, pipelineConfig backends.PipelineConfig[T], options *options.Options, model *backends.Model) (T, string, error) {
 	var pipeline T
 	var name string
 
 	switch any(p).(type) {
 	case *pipelines.TokenClassificationPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.TokenClassificationPipeline])
-		pipelineInitialised, err := pipelines.NewTokenClassificationPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewTokenClassificationPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -211,7 +218,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.TextClassificationPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.TextClassificationPipeline])
-		pipelineInitialised, err := pipelines.NewTextClassificationPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewTextClassificationPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -219,7 +226,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.FeatureExtractionPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.FeatureExtractionPipeline])
-		pipelineInitialised, err := pipelines.NewFeatureExtractionPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewFeatureExtractionPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -227,7 +234,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.ZeroShotClassificationPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.ZeroShotClassificationPipeline])
-		pipelineInitialised, err := pipelines.NewZeroShotClassificationPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewZeroShotClassificationPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -235,7 +242,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.CrossEncoderPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.CrossEncoderPipeline])
-		pipelineInitialised, err := pipelines.NewCrossEncoderPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewCrossEncoderPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -243,7 +250,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.ImageClassificationPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.ImageClassificationPipeline])
-		pipelineInitialised, err := pipelines.NewImageClassificationPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewImageClassificationPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -251,7 +258,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.ObjectDetectionPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.ObjectDetectionPipeline])
-		pipelineInitialised, err := pipelines.NewObjectDetectionPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewObjectDetectionPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -259,7 +266,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.TextGenerationPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.TextGenerationPipeline])
-		pipelineInitialised, err := pipelines.NewTextGenerationPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewTextGenerationPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -267,7 +274,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.TabularPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.TabularPipeline])
-		pipelineInitialised, err := pipelines.NewTabularPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewTabularPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -275,7 +282,7 @@ func InitializePipeline[T backends.Pipeline](p T, pipelineConfig backends.Pipeli
 		name = config.Name
 	case *pipelines.QuestionAnsweringPipeline:
 		config := any(pipelineConfig).(backends.PipelineConfig[*pipelines.QuestionAnsweringPipeline])
-		pipelineInitialised, err := pipelines.NewQuestionAnsweringPipeline(config, options, model)
+		pipelineInitialised, err := pipelines.NewQuestionAnsweringPipeline(sessionContext, config, options, model)
 		if err != nil {
 			return pipeline, name, err
 		}
@@ -539,5 +546,12 @@ func (s *Session) Destroy() error {
 	}
 
 	err = errors.Join(err, s.environmentDestroy())
+
+	if s.cancelSessionContext != nil {
+		s.cancelSessionContext()
+		s.cancelSessionContext = nil
+		s.sessionContext = nil
+	}
+
 	return err
 }

--- a/hugot_go.go
+++ b/hugot_go.go
@@ -1,11 +1,13 @@
 package hugot
 
 import (
+	"context"
+
 	_ "github.com/gomlx/gomlx/backends/simplego" // Import simplego backend
 
 	"github.com/knights-analytics/hugot/options"
 )
 
-func NewGoSession(opts ...options.WithOption) (*Session, error) {
-	return newSession("GO", opts...)
+func NewGoSession(ctx context.Context, opts ...options.WithOption) (*Session, error) {
+	return newSession(ctx, "GO", opts...)
 }

--- a/hugot_go_test.go
+++ b/hugot_go_test.go
@@ -12,7 +12,7 @@ import (
 // FEATURE EXTRACTION
 
 func TestFeatureExtractionPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -22,7 +22,7 @@ func TestFeatureExtractionPipelineGo(t *testing.T) {
 }
 
 func TestFeatureExtractionPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -34,7 +34,7 @@ func TestFeatureExtractionPipelineValidationGo(t *testing.T) {
 // Text classification
 
 func TestTextClassificationPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -44,7 +44,7 @@ func TestTextClassificationPipelineGo(t *testing.T) {
 }
 
 func TestTextClassificationPipelineMultiGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -54,7 +54,7 @@ func TestTextClassificationPipelineMultiGo(t *testing.T) {
 }
 
 func TestTextClassificationPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -66,7 +66,7 @@ func TestTextClassificationPipelineValidationGo(t *testing.T) {
 // Token classification
 
 func TestTokenClassificationPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -76,7 +76,7 @@ func TestTokenClassificationPipelineGo(t *testing.T) {
 }
 
 func TestTokenClassificationPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -88,7 +88,7 @@ func TestTokenClassificationPipelineValidationGo(t *testing.T) {
 // Zero shot
 
 func TestZeroShotClassificationPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -98,7 +98,7 @@ func TestZeroShotClassificationPipelineGo(t *testing.T) {
 }
 
 func TestZeroShotClassificationPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -110,7 +110,7 @@ func TestZeroShotClassificationPipelineValidationGo(t *testing.T) {
 // Cross Encoder
 
 func TestCrossEncoderPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -120,7 +120,7 @@ func TestCrossEncoderPipelineGo(t *testing.T) {
 }
 
 func TestCrossEncoderPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -132,7 +132,7 @@ func TestCrossEncoderPipelineValidationGo(t *testing.T) {
 // Image classification
 
 func TestImageClassificationPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -142,7 +142,7 @@ func TestImageClassificationPipelineGo(t *testing.T) {
 }
 
 func TestImageClassificationPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -154,7 +154,7 @@ func TestImageClassificationPipelineValidationGo(t *testing.T) {
 // Object detection
 
 func TestObjectDetectionPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -164,7 +164,7 @@ func TestObjectDetectionPipelineGo(t *testing.T) {
 }
 
 func TestObjectDetectionPipelineValidationGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -177,7 +177,7 @@ func TestObjectDetectionPipelineValidationGo(t *testing.T) {
 
 func TestTextGenerationPipelineGo(t *testing.T) {
 	t.Skip("Generative models are not supported yet for Go")
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -188,7 +188,7 @@ func TestTextGenerationPipelineGo(t *testing.T) {
 
 func TestTextGenerationPipelineValidationGo(t *testing.T) {
 	t.Skip("Generative models are not supported yet for Go")
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -201,7 +201,7 @@ func TestTextGenerationPipelineValidationGo(t *testing.T) {
 
 func TestTabularPipelineGo(t *testing.T) {
 	t.Skip("Currently missing TreeEnsembleClassifier ONNX operator")
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -213,7 +213,7 @@ func TestTabularPipelineGo(t *testing.T) {
 // QA
 
 func TestQAPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -225,7 +225,7 @@ func TestQAPipelineGo(t *testing.T) {
 // No same name
 
 func TestNoSameNamePipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -235,7 +235,7 @@ func TestNoSameNamePipelineGo(t *testing.T) {
 }
 
 func TestDestroyPipelineGo(t *testing.T) {
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -250,7 +250,7 @@ func TestThreadSafetyGo(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -270,7 +270,7 @@ func TestReadmeExample(t *testing.T) {
 	}
 
 	// start a new session
-	session, err := NewGoSession()
+	session, err := NewGoSession(t.Context())
 	// For XLA (requires go build tags "XLA" or "ALL"):
 	// session, err := NewXLASession()
 	// For ORT (requires go build tags "ORT" or "ALL"):
@@ -307,7 +307,7 @@ func TestReadmeExample(t *testing.T) {
 
 	// we can now use the pipeline for prediction on a batch of strings
 	batch := []string{"This movie is disgustingly good !", "The director tried too much"}
-	batchResult, err := sentimentPipeline.RunPipeline(batch)
+	batchResult, err := sentimentPipeline.RunPipeline(t.Context(), batch)
 	check(err)
 
 	// and do whatever we want with it :)

--- a/hugot_ort.go
+++ b/hugot_ort.go
@@ -3,6 +3,7 @@
 package hugot
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -13,12 +14,12 @@ import (
 	"github.com/knights-analytics/hugot/util/fileutil"
 )
 
-func NewORTSession(opts ...options.WithOption) (*Session, error) {
+func NewORTSession(ctx context.Context, opts ...options.WithOption) (*Session, error) {
 	if ort.IsInitialized() {
 		return nil, errors.New("another session is currently active, and only one session can be active at one time")
 	}
 
-	session, err := newSession("ORT", opts...)
+	session, err := newSession(ctx, "ORT", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/hugot_ort_disabled.go
+++ b/hugot_ort_disabled.go
@@ -3,11 +3,12 @@
 package hugot
 
 import (
+	"context"
 	"errors"
 
 	"github.com/knights-analytics/hugot/options"
 )
 
-func NewORTSession(_ ...options.WithOption) (*Session, error) {
+func NewORTSession(_ context.Context, _ ...options.WithOption) (*Session, error) {
 	return nil, errors.New("to enable ORT, run `go build -tags ORT` or `go build -tags ALL`")
 }

--- a/hugot_ort_test.go
+++ b/hugot_ort_test.go
@@ -3,6 +3,7 @@
 package hugot
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -13,7 +14,7 @@ import (
 // FEATURE EXTRACTION
 
 func TestFeatureExtractionPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -26,7 +27,7 @@ func TestFeatureExtractionPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -38,7 +39,7 @@ func TestFeatureExtractionPipelineORTCuda(t *testing.T) {
 }
 
 func TestFeatureExtractionPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -58,7 +59,7 @@ func TestTextClassificationPipelineORT(t *testing.T) {
 		options.WithIntraOpNumThreads(1),
 		options.WithInterOpNumThreads(1),
 	}
-	session, err := NewORTSession(opts...)
+	session, err := NewORTSession(t.Context(), opts...)
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -71,7 +72,7 @@ func TestTextClassificationPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -91,7 +92,7 @@ func TestTextClassificationPipelineMultiORT(t *testing.T) {
 		options.WithIntraOpNumThreads(1),
 		options.WithInterOpNumThreads(1),
 	}
-	session, err := NewORTSession(opts...)
+	session, err := NewORTSession(t.Context(), opts...)
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -104,7 +105,7 @@ func TestTextClassificationPipelineORTMultiCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -116,7 +117,7 @@ func TestTextClassificationPipelineORTMultiCuda(t *testing.T) {
 }
 
 func TestTextClassificationPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -128,7 +129,7 @@ func TestTextClassificationPipelineValidationORT(t *testing.T) {
 // Token classification
 
 func TestTokenClassificationPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -141,7 +142,7 @@ func TestTokenClassificationPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -153,7 +154,7 @@ func TestTokenClassificationPipelineORTCuda(t *testing.T) {
 }
 
 func TestTokenClassificationPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -165,7 +166,7 @@ func TestTokenClassificationPipelineValidationORT(t *testing.T) {
 // Zero shot
 
 func TestZeroShotClassificationPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -178,7 +179,7 @@ func TestZeroShotClassificationPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -190,7 +191,7 @@ func TestZeroShotClassificationPipelineORTCuda(t *testing.T) {
 }
 
 func TestZeroShotClassificationPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -202,7 +203,7 @@ func TestZeroShotClassificationPipelineValidationORT(t *testing.T) {
 // Cross Encoder
 
 func TestCrossEncoderPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -215,7 +216,7 @@ func TestCrossEncoderPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -227,7 +228,7 @@ func TestCrossEncoderPipelineORTCuda(t *testing.T) {
 }
 
 func TestCrossEncoderPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -239,7 +240,7 @@ func TestCrossEncoderPipelineValidationORT(t *testing.T) {
 // Image classification
 
 func TestImageClassificationPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -252,7 +253,7 @@ func TestImageClassificationPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -264,7 +265,7 @@ func TestImageClassificationPipelineORTCuda(t *testing.T) {
 }
 
 func TestImageClassificationPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -276,7 +277,7 @@ func TestImageClassificationPipelineValidationORT(t *testing.T) {
 // Object detection
 
 func TestObjectDetectionPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -289,7 +290,7 @@ func TestObjectDetectionPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -301,7 +302,7 @@ func TestObjectDetectionPipelineORTCuda(t *testing.T) {
 }
 
 func TestObjectDetectionPipelineValidationORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -317,7 +318,7 @@ func TestTextGenerationPipelineORT(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -330,7 +331,7 @@ func TestTextGenerationPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -345,7 +346,7 @@ func TestTextGenerationPipelineValidationORT(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -357,7 +358,7 @@ func TestTextGenerationPipelineValidationORT(t *testing.T) {
 // Question answering
 
 func TestQAPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -370,7 +371,7 @@ func TestQAPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -384,7 +385,7 @@ func TestQAPipelineORTCuda(t *testing.T) {
 // Tabular pipeline
 
 func TestTabularPipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -397,7 +398,7 @@ func TestTabularPipelineORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -411,7 +412,7 @@ func TestTabularPipelineORTCuda(t *testing.T) {
 // No same name
 
 func TestNoSameNamePipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -421,7 +422,7 @@ func TestNoSameNamePipelineORT(t *testing.T) {
 }
 
 func TestClosePipelineORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -433,7 +434,7 @@ func TestClosePipelineORT(t *testing.T) {
 // Thread safety
 
 func TestThreadSafetyORT(t *testing.T) {
-	session, err := NewORTSession()
+	session, err := NewORTSession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -446,7 +447,7 @@ func TestThreadSafetyORTCuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewORTSession(options.WithCuda(map[string]string{
+	session, err := NewORTSession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -459,7 +460,7 @@ func TestThreadSafetyORTCuda(t *testing.T) {
 
 // Benchmarks
 
-func runBenchmarkEmbedding(strings *[]string, cuda bool) {
+func runBenchmarkEmbedding(ctx context.Context, strings *[]string, cuda bool) {
 	var opts []options.WithOption
 	switch cuda {
 	case true:
@@ -471,7 +472,7 @@ func runBenchmarkEmbedding(strings *[]string, cuda bool) {
 	default:
 		opts = []options.WithOption{}
 	}
-	session, err := NewORTSession(opts...)
+	session, err := NewORTSession(ctx, opts...)
 	if err != nil {
 		panic(err)
 	}
@@ -492,7 +493,7 @@ func runBenchmarkEmbedding(strings *[]string, cuda bool) {
 	if err2 != nil {
 		panic(err2)
 	}
-	res, err := pipelineEmbedder.Run(*strings)
+	res, err := pipelineEmbedder.Run(ctx, *strings)
 	if err != nil {
 		panic(err)
 	}
@@ -508,7 +509,7 @@ func BenchmarkORTCudaEmbedding(b *testing.B) {
 		p[i] = "The goal of this library is to provide an easy, scalable, and hassle-free way to run huggingface transformer pipelines in golang applications."
 	}
 	for b.Loop() {
-		runBenchmarkEmbedding(&p, true)
+		runBenchmarkEmbedding(b.Context(), &p, true)
 	}
 }
 
@@ -521,6 +522,6 @@ func BenchmarkORTCPUEmbedding(b *testing.B) {
 		p[i] = "The goal of this library is to provide an easy, scalable, and hassle-free way to run huggingface transformer pipelines in golang applications."
 	}
 	for b.Loop() {
-		runBenchmarkEmbedding(&p, false)
+		runBenchmarkEmbedding(b.Context(), &p, false)
 	}
 }

--- a/hugot_test.go
+++ b/hugot_test.go
@@ -55,7 +55,7 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 
 	// test 'robert smith'
 	testResults = expectedResults["test1output"]
-	batchResult, err := pipeline.RunPipeline([]string{"robert smith"})
+	batchResult, err := pipeline.RunPipeline(t.Context(), []string{"robert smith"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 
 	// test ['robert smith junior', 'francis ford coppola']
 	testResults = expectedResults["test2output"]
-	batchResult, err = pipeline.RunPipeline([]string{"robert smith junior", "francis ford coppola"})
+	batchResult, err = pipeline.RunPipeline(t.Context(), []string{"robert smith junior", "francis ford coppola"})
 	if err != nil {
 		t.FailNow()
 	}
@@ -89,11 +89,11 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 
 	for k, sentencePair := range testPairs {
 		// these vectors should be the same
-		firstBatchResult, err2 := pipeline.RunPipeline(sentencePair[0])
+		firstBatchResult, err2 := pipeline.RunPipeline(t.Context(), sentencePair[0])
 		checkT(t, err2)
 		firstEmbedding := firstBatchResult.Embeddings[0]
 
-		secondBatchResult, err3 := pipeline.RunPipeline(sentencePair[1])
+		secondBatchResult, err3 := pipeline.RunPipeline(t.Context(), sentencePair[1])
 		checkT(t, err3)
 		secondEmbedding := secondBatchResult.Embeddings[0]
 		e := floatsEqual(firstEmbedding, secondEmbedding)
@@ -125,7 +125,7 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 	checkT(t, err)
 
 	normalizationStrings := []string{"Onnxruntime is a great inference backend"}
-	normalizedEmbedding, err := pipeline.RunPipeline(normalizationStrings)
+	normalizedEmbedding, err := pipeline.RunPipeline(t.Context(), normalizationStrings)
 	checkT(t, err)
 	for i, embedding := range normalizedEmbedding.Embeddings {
 		e := floatsEqual(embedding, testResults[i])
@@ -144,7 +144,7 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 	pipelineSentence, err := NewPipeline(session, configSentence)
 	checkT(t, err)
 
-	_, err = pipelineSentence.RunPipeline([]string{"Onnxruntime is a great inference backend"})
+	_, err = pipelineSentence.RunPipeline(t.Context(), []string{"Onnxruntime is a great inference backend"})
 	if err != nil {
 		t.FailNow()
 	}
@@ -155,7 +155,7 @@ func featureExtractionPipeline(t *testing.T, session *Session) {
 	}
 	pipelineToken, err := NewPipeline(session, configSentence)
 	checkT(t, err)
-	_, err = pipelineToken.RunPipeline([]string{"Onnxruntime is a great inference backend"})
+	_, err = pipelineToken.RunPipeline(t.Context(), []string{"Onnxruntime is a great inference backend"})
 	if err != nil {
 		t.FailNow()
 	}
@@ -228,7 +228,7 @@ func textClassificationPipeline(t *testing.T, session *Session) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
-		batchResult, err := test.pipeline.RunPipeline(test.strings)
+		batchResult, err := test.pipeline.RunPipeline(t.Context(), test.strings)
 		checkT(t, err)
 		for i, expected := range test.expected.ClassificationOutputs {
 			checkClassificationOutput(t, expected, batchResult.ClassificationOutputs[i])
@@ -387,7 +387,7 @@ func textClassificationPipelineMulti(t *testing.T, session *Session) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
-		batchResult, err := test.pipeline.RunPipeline(test.strings)
+		batchResult, err := test.pipeline.RunPipeline(t.Context(), test.strings)
 		checkT(t, err)
 		for i, expected := range test.expected.ClassificationOutputs {
 			checkClassificationOutput(t, expected, batchResult.ClassificationOutputs[i])
@@ -647,7 +647,7 @@ func zeroShotClassificationPipeline(t *testing.T, session *Session) {
 		t.Run(tt.name, func(t *testing.T) {
 			classificationPipeline.Labels = tt.labels
 			classificationPipeline.Multilabel = tt.multilabel
-			batchResult, err := tt.pipeline.RunPipeline(tt.sequences)
+			batchResult, err := tt.pipeline.RunPipeline(t.Context(), tt.sequences)
 			checkT(t, err)
 			assert.Equal(t, len(batchResult.GetOutput()), len(tt.expected.ClassificationOutputs))
 
@@ -769,7 +769,7 @@ func tokenClassificationPipeline(t *testing.T, session *Session) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			batchResult, err := tt.pipeline.RunPipeline(tt.strings)
+			batchResult, err := tt.pipeline.RunPipeline(t.Context(), tt.strings)
 			checkT(t, err)
 			printTokenEntities(batchResult)
 			for i, predictedEntities := range batchResult.Entities {
@@ -786,7 +786,7 @@ func tokenClassificationPipeline(t *testing.T, session *Session) {
 	// Expect same entities as the simple aggregation for the equivalent sentence for split words
 	t.Run("Split words aggregation", func(t *testing.T) {
 		words := [][]string{{"My", "name", "is", "Wolfgang", "and", "I", "live", "in", "Berlin", "."}}
-		batchResult, err := pipelineSplit.RunWords(words)
+		batchResult, err := pipelineSplit.RunWords(t.Context(), words)
 		checkT(t, err)
 		printTokenEntities(batchResult)
 		expected := expectedResults[0]
@@ -805,9 +805,9 @@ func tokenClassificationPipeline(t *testing.T, session *Session) {
 		nonSplit := []string{"New  York is great."}
 		splitWords := [][]string{{"New", "York", "is", "great", "."}}
 
-		resNonSplit, errNon := pipelineSimple.RunPipeline(nonSplit)
+		resNonSplit, errNon := pipelineSimple.RunPipeline(t.Context(), nonSplit)
 		checkT(t, errNon)
-		resSplit, errSplitRun := pipelineSplit.RunWords(splitWords)
+		resSplit, errSplitRun := pipelineSplit.RunWords(t.Context(), splitWords)
 		checkT(t, errSplitRun)
 
 		// Compare first sequence: entity words may match, but offsets should differ due to space normalization.
@@ -823,9 +823,9 @@ func tokenClassificationPipeline(t *testing.T, session *Session) {
 		nonSplit := []string{"XBerlinXXisXbeautiful."}
 		split := [][]string{{"Berlin is", "beautiful", "."}}
 
-		resNonSplit, errNS := pipelineSimple.RunPipeline(nonSplit)
+		resNonSplit, errNS := pipelineSimple.RunPipeline(t.Context(), nonSplit)
 		checkT(t, errNS)
-		resSplit, errSW := pipelineSplit.RunWords(split)
+		resSplit, errSW := pipelineSplit.RunWords(t.Context(), split)
 		checkT(t, errSW)
 
 		gotA := resNonSplit.Entities[0]
@@ -923,7 +923,7 @@ func crossEncoderPipeline(t *testing.T, session *Session) {
 	}
 
 	inputs := append([]string{query}, documents...)
-	output, err := pipeline.Run(inputs)
+	output, err := pipeline.Run(t.Context(), inputs)
 	checkT(t, err)
 	results := output.(*pipelines.CrossEncoderOutput).Results
 
@@ -996,7 +996,7 @@ func imageClassificationPipeline(t *testing.T, session *Session) {
 	pipeline, err := NewPipeline(session, config)
 	checkT(t, err)
 
-	result, err := pipeline.RunPipeline([]string{imagePath, imagePath})
+	result, err := pipeline.RunPipeline(t.Context(), []string{imagePath, imagePath})
 	checkT(t, err)
 
 	for i, pred := range result.Predictions[0] {
@@ -1045,7 +1045,7 @@ func objectDetectionPipeline(t *testing.T, session *Session) {
 
 	// Use a simple cat image similar to classification test style
 	inputs := []string{"models/imageData/cat.jpg"}
-	result, err := pipeline.RunPipeline(inputs)
+	result, err := pipeline.RunPipeline(t.Context(), inputs)
 	checkT(t, err)
 
 	if len(result.Detections) == 0 || len(result.Detections[0]) == 0 {
@@ -1424,7 +1424,7 @@ func questionAnsweringPipeline(t *testing.T, session *Session) {
 		{Question: "What is the currency?", Context: contextJSON},
 	}
 
-	result, err := pipeline.RunPipeline(inputs)
+	result, err := pipeline.RunPipeline(t.Context(), inputs)
 	checkT(t, err)
 
 	assert.Equal(t, 2, len(result.Outputs), "expected one result per input")
@@ -1457,7 +1457,7 @@ func questionAnsweringPipeline(t *testing.T, session *Session) {
 	pipelineTopK, err := NewPipeline(session, configTopK)
 	checkT(t, err)
 
-	resultTopK, err := pipelineTopK.RunPipeline(inputs)
+	resultTopK, err := pipelineTopK.RunPipeline(t.Context(), inputs)
 	checkT(t, err)
 
 	assert.Equal(t, 2, len(resultTopK.Outputs), "expected one result set per input")
@@ -1491,7 +1491,7 @@ func tabularPipeline(t *testing.T, session *Session) {
 
 	// Iris classification for an example
 	inputs := []string{"[6.1, 2.8, 4.7, 1.2]"}
-	result, err := pipeline.Run(inputs)
+	result, err := pipeline.Run(t.Context(), inputs)
 	checkT(t, err)
 	output := result.GetOutput()
 	classification := output[0].(pipelines.TabularClassificationOutput)
@@ -1536,12 +1536,12 @@ func threadSafety(t *testing.T, session *Session, numEmbeddings int) {
 
 	worker := func() {
 		for range numEmbeddings {
-			batchResult, threadErr := pipeline.RunPipeline([]string{"robert smith"})
+			batchResult, threadErr := pipeline.RunPipeline(t.Context(), []string{"robert smith"})
 			if threadErr != nil {
 				errChannel <- threadErr
 			}
 			outputChannel1 <- batchResult.Embeddings
-			batchResult, threadErr = pipeline.RunPipeline([]string{"robert smith junior", "francis ford coppola"})
+			batchResult, threadErr = pipeline.RunPipeline(t.Context(), []string{"robert smith junior", "francis ford coppola"})
 			if threadErr != nil {
 				errChannel <- threadErr
 			}

--- a/hugot_training.go
+++ b/hugot_training.go
@@ -116,7 +116,7 @@ type TrainingConfig struct {
 	Verbose              bool
 }
 
-func newTrainingSession[T backends.Pipeline](backend string, config TrainingConfig) (*TrainingSession, error) {
+func newTrainingSession[T backends.Pipeline](sessionContext context.Context, backend string, config TrainingConfig) (*TrainingSession, error) {
 	session := &TrainingSession{
 		config:  config,
 		backend: backend,
@@ -150,7 +150,7 @@ func newTrainingSession[T backends.Pipeline](backend string, config TrainingConf
 	case *pipelines.FeatureExtractionPipeline:
 		pipelineConfig := FeatureExtractionConfig{}
 		pipeline := any(trainingPipeline).(*pipelines.FeatureExtractionPipeline)
-		pipeline, _, err = InitializePipeline(pipeline, pipelineConfig, opts, model)
+		pipeline, _, err = initializePipeline(sessionContext, pipeline, pipelineConfig, opts, model)
 		if err != nil {
 			return nil, err
 		}

--- a/hugot_training_gomlx.go
+++ b/hugot_training_gomlx.go
@@ -1,6 +1,7 @@
 package hugot
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -11,7 +12,7 @@ import (
 
 	"github.com/gomlx/gomlx/pkg/core/graph"
 	"github.com/gomlx/gomlx/pkg/core/tensors"
-	"github.com/gomlx/gomlx/pkg/ml/context"
+	gomlxcontext "github.com/gomlx/gomlx/pkg/ml/context"
 	"github.com/gomlx/gomlx/pkg/ml/train"
 	"github.com/gomlx/gomlx/pkg/ml/train/losses"
 	"github.com/gomlx/gomlx/pkg/ml/train/optimizers"
@@ -32,8 +33,8 @@ func (e stoppingError) Error() string {
 	return "stopping error"
 }
 
-func NewGoTrainingSession[T backends.Pipeline](config TrainingConfig) (*TrainingSession, error) {
-	s, err := newTrainingSession[T]("GO", config)
+func NewGoTrainingSession[T backends.Pipeline](ctx context.Context, config TrainingConfig) (*TrainingSession, error) {
+	s, err := newTrainingSession[T](ctx, "GO", config)
 	if err != nil {
 		return nil, err
 	}
@@ -41,11 +42,11 @@ func NewGoTrainingSession[T backends.Pipeline](config TrainingConfig) (*Training
 	return newGoMLXTrainingSession(s)
 }
 
-func NewXLATrainingSession[T backends.Pipeline](config TrainingConfig) (*TrainingSession, error) {
+func NewXLATrainingSession[T backends.Pipeline](ctx context.Context, config TrainingConfig) (*TrainingSession, error) {
 	// Disabled for now until we have auto installs globally
 	xlaDisableAutoInstall()
 
-	s, err := newTrainingSession[T]("XLA", config)
+	s, err := newTrainingSession[T](ctx, "XLA", config)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func TrainGoMLX(s *TrainingSession) error {
 			}
 		}
 
-		modelFn := func(ctx *context.Context, _ any, inputs []*context.Node) []*context.Node {
+		modelFn := func(ctx *gomlxcontext.Context, _ any, inputs []*gomlxcontext.Node) []*gomlxcontext.Node {
 			inputsLHS := inputs[:3] // inputIDs, attentionMask, tokenTypeIDs if present
 			inputsRHS := inputs[3:]
 
@@ -124,7 +125,7 @@ func TrainGoMLX(s *TrainingSession) error {
 				embeddingRHS = graph.MaskedReduceMean(embeddingRHS, maskRHS, 1)
 			}
 			cosineSimilarity := graph.CosineSimilarity(embeddingLHS, embeddingRHS, -1)
-			return []*context.Node{cosineSimilarity}
+			return []*gomlxcontext.Node{cosineSimilarity}
 		}
 
 		gomlxTrainer := train.NewTrainer(backend,

--- a/hugot_training_test.go
+++ b/hugot_training_test.go
@@ -6,10 +6,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/knights-analytics/hugot/options"
 	"math"
 	"os"
 	"testing"
+
+	"github.com/knights-analytics/hugot/options"
 
 	"github.com/stretchr/testify/assert"
 
@@ -38,13 +39,13 @@ func runModel(t *testing.T, runtime string, examplesLeft, examplesRight []string
 
 	switch runtime {
 	case "ORT":
-		session, err = NewORTSession()
+		session, err = NewORTSession(t.Context())
 		checkT(t, err)
 	case "GO":
-		session, err = NewGoSession()
+		session, err = NewGoSession(t.Context())
 		checkT(t, err)
 	case "XLA":
-		session, err = NewXLASession(options.WithGoMLXBatchBuckets([]int{35}))
+		session, err = NewXLASession(t.Context(), options.WithGoMLXBatchBuckets([]int{35}))
 		checkT(t, err)
 	default:
 		t.Fatal("unknown runtime")
@@ -62,9 +63,9 @@ func runModel(t *testing.T, runtime string, examplesLeft, examplesRight []string
 	pipeline, err := NewPipeline(session, config)
 	checkT(t, err)
 
-	resultsLeft, err := pipeline.RunPipeline(examplesLeft)
+	resultsLeft, err := pipeline.RunPipeline(t.Context(), examplesLeft)
 	checkT(t, err)
-	resultsRight, err := pipeline.RunPipeline(examplesRight)
+	resultsRight, err := pipeline.RunPipeline(t.Context(), examplesRight)
 	checkT(t, err)
 
 	// calculate cosine similarity between the embeddings
@@ -89,7 +90,7 @@ func trainSimilarity(t *testing.T,
 	// Create a new GoMLX training session. Currently, training is only possible by loading an onnx model
 	// into GoMLX, fine-tuning it, and then writing it back to onnx. Hugot deals with the details
 	// for you here.
-	trainingSession, err := NewXLATrainingSession[*pipelines.FeatureExtractionPipeline](config)
+	trainingSession, err := NewXLATrainingSession[*pipelines.FeatureExtractionPipeline](t.Context(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,6 +252,7 @@ func TestTrainSemanticSimilarityCuda(t *testing.T) {
 	modelPath := "./models/KnightsAnalytics_all-MiniLM-L6-v2"
 
 	session, err := NewXLATrainingSession[*pipelines.FeatureExtractionPipeline](
+		t.Context(),
 		TrainingConfig{
 			ModelPath:    modelPath,
 			TrainDataset: dataset,
@@ -297,6 +299,7 @@ func TestTrainSemanticSimilarityGo(t *testing.T) {
 	modelPath := "./models/KnightsAnalytics_all-MiniLM-L6-v2"
 
 	session, err := NewGoTrainingSession[*pipelines.FeatureExtractionPipeline](
+		t.Context(),
 		TrainingConfig{
 			ModelPath:    modelPath,
 			TrainDataset: dataset,
@@ -358,7 +361,7 @@ func TestEarlyStopping(t *testing.T) {
 		Verbose: true,
 	}
 
-	trainingSession, err := NewXLATrainingSession[*pipelines.FeatureExtractionPipeline](trainingConfig)
+	trainingSession, err := NewXLATrainingSession[*pipelines.FeatureExtractionPipeline](t.Context(), trainingConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hugot_xla.go
+++ b/hugot_xla.go
@@ -3,15 +3,17 @@
 package hugot
 
 import (
+	"context"
+
 	"github.com/gomlx/gomlx/backends/xla" // import XLA backend
 
 	"github.com/knights-analytics/hugot/options"
 )
 
-func NewXLASession(opts ...options.WithOption) (*Session, error) {
+func NewXLASession(ctx context.Context, opts ...options.WithOption) (*Session, error) {
 	// Disabled for now until we have auto installs globally
 	xlaDisableAutoInstall()
-	return newSession("XLA", opts...)
+	return newSession(ctx, "XLA", opts...)
 }
 
 func xlaDisableAutoInstall() {

--- a/hugot_xla_disabled.go
+++ b/hugot_xla_disabled.go
@@ -3,12 +3,13 @@
 package hugot
 
 import (
+	"context"
 	"errors"
 
 	"github.com/knights-analytics/hugot/options"
 )
 
-func NewXLASession(_ ...options.WithOption) (*Session, error) {
+func NewXLASession(_ context.Context, _ ...options.WithOption) (*Session, error) {
 	return nil, errors.New("to enable XLA, run `go build -tags XLA` or `go build -tags ALL`")
 }
 

--- a/hugot_xla_test.go
+++ b/hugot_xla_test.go
@@ -12,7 +12,7 @@ import (
 // FEATURE EXTRACTION
 
 func TestFeatureExtractionPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -25,7 +25,7 @@ func TestFeatureExtractionPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -37,7 +37,7 @@ func TestFeatureExtractionPipelineXLACuda(t *testing.T) {
 }
 
 func TestFeatureExtractionPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -49,7 +49,7 @@ func TestFeatureExtractionPipelineValidationXLA(t *testing.T) {
 // Text classification
 
 func TestTextClassificationPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -62,7 +62,7 @@ func TestTextClassificationPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -74,7 +74,7 @@ func TestTextClassificationPipelineXLACuda(t *testing.T) {
 }
 
 func TestTextClassificationPipelineMultiXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -87,7 +87,7 @@ func TestTextClassificationPipelineMultiXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -99,7 +99,7 @@ func TestTextClassificationPipelineMultiXLACuda(t *testing.T) {
 }
 
 func TestTextClassificationPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -111,7 +111,7 @@ func TestTextClassificationPipelineValidationXLA(t *testing.T) {
 // Token classification
 
 func TestTokenClassificationPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -124,7 +124,7 @@ func TestTokenClassificationPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -136,7 +136,7 @@ func TestTokenClassificationPipelineXLACuda(t *testing.T) {
 }
 
 func TestTokenClassificationPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -148,7 +148,7 @@ func TestTokenClassificationPipelineValidationXLA(t *testing.T) {
 // Zero shot
 
 func TestZeroShotClassificationPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -161,7 +161,7 @@ func TestZeroShotClassificationPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -173,7 +173,7 @@ func TestZeroShotClassificationPipelineXLACuda(t *testing.T) {
 }
 
 func TestZeroShotClassificationPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -185,7 +185,7 @@ func TestZeroShotClassificationPipelineValidationXLA(t *testing.T) {
 // Cross Encoder
 
 func TestCrossEncoderPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -198,7 +198,7 @@ func TestCrossEncoderPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -210,7 +210,7 @@ func TestCrossEncoderPipelineXLACuda(t *testing.T) {
 }
 
 func TestCrossEncoderPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -222,7 +222,7 @@ func TestCrossEncoderPipelineValidationXLA(t *testing.T) {
 // Image classification
 
 func TestImageClassificationPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -235,7 +235,7 @@ func TestImageClassificationPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -247,7 +247,7 @@ func TestImageClassificationPipelineXLACuda(t *testing.T) {
 }
 
 func TestImageClassificationPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -259,7 +259,7 @@ func TestImageClassificationPipelineValidationXLA(t *testing.T) {
 // Object detection
 
 func TestObjectDetectionPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -272,7 +272,7 @@ func TestObjectDetectionPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -284,7 +284,7 @@ func TestObjectDetectionPipelineXLACuda(t *testing.T) {
 }
 
 func TestObjectDetectionPipelineValidationXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -297,7 +297,7 @@ func TestObjectDetectionPipelineValidationXLA(t *testing.T) {
 
 func TestTextGenerationPipelineXLA(t *testing.T) {
 	t.Skip("Generative models are not supported yet for XLA")
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -311,7 +311,7 @@ func TestTextGenerationPipelineXLACuda(t *testing.T) {
 		t.SkipNow()
 	}
 	t.Skip("Generative models are not supported yet for XLA")
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -324,7 +324,7 @@ func TestTextGenerationPipelineXLACuda(t *testing.T) {
 
 func TestTextGenerationPipelineValidationXLA(t *testing.T) {
 	t.Skip("Generative models are not supported yet for XLA")
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -337,7 +337,7 @@ func TestTextGenerationPipelineValidationXLA(t *testing.T) {
 
 func TestTabularPipelineXLA(t *testing.T) {
 	t.Skip("Currently missing TreeEnsembleClassifier ONNX operator")
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -351,7 +351,7 @@ func TestTabularPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -365,7 +365,7 @@ func TestTabularPipelineXLACuda(t *testing.T) {
 // Question answering
 
 func TestQuestionAnsweringPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -378,7 +378,7 @@ func TestQuestionAnsweringPipelineXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)
@@ -392,7 +392,7 @@ func TestQuestionAnsweringPipelineXLACuda(t *testing.T) {
 // No same name
 
 func TestNoSameNamePipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -402,7 +402,7 @@ func TestNoSameNamePipelineXLA(t *testing.T) {
 }
 
 func TestDestroyPipelineXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -414,7 +414,7 @@ func TestDestroyPipelineXLA(t *testing.T) {
 // Thread safety
 
 func TestThreadSafetyXLA(t *testing.T) {
-	session, err := NewXLASession()
+	session, err := NewXLASession(t.Context())
 	checkT(t, err)
 	defer func(session *Session) {
 		destroyErr := session.Destroy()
@@ -427,7 +427,7 @@ func TestThreadSafetyXLACuda(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.SkipNow()
 	}
-	session, err := NewXLASession(options.WithCuda(map[string]string{
+	session, err := NewXLASession(t.Context(), options.WithCuda(map[string]string{
 		"device_id": "0",
 	}))
 	checkT(t, err)

--- a/pipelines/crossEncoder.go
+++ b/pipelines/crossEncoder.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -65,8 +66,8 @@ func (t *CrossEncoderOutput) GetOutput() []any {
 	return out
 }
 
-func NewCrossEncoderPipeline(config backends.PipelineConfig[*CrossEncoderPipeline], s *options.Options, model *backends.Model) (*CrossEncoderPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewCrossEncoderPipeline(sessionContext context.Context, config backends.PipelineConfig[*CrossEncoderPipeline], s *options.Options, model *backends.Model) (*CrossEncoderPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +158,7 @@ func (p *CrossEncoderPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-func (p *CrossEncoderPipeline) Preprocess(batch *backends.PipelineBatch, inputs []string) error {
+func (p *CrossEncoderPipeline) preprocess(batch *backends.PipelineBatch, inputs []string) error {
 	start := time.Now()
 	backends.TokenizeInputs(batch, p.Model.Tokenizer, inputs)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -166,7 +167,7 @@ func (p *CrossEncoderPipeline) Preprocess(batch *backends.PipelineBatch, inputs 
 	return err
 }
 
-func (p *CrossEncoderPipeline) PreprocessPairs(batch *backends.PipelineBatch, inputs [][2]string) error {
+func (p *CrossEncoderPipeline) preprocessPairs(batch *backends.PipelineBatch, inputs [][2]string) error {
 	start := time.Now()
 	backends.TokenizeInputPairs(batch, p.Model.Tokenizer, inputs, p.Model.SeparatorToken)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -175,12 +176,12 @@ func (p *CrossEncoderPipeline) PreprocessPairs(batch *backends.PipelineBatch, in
 	return err
 }
 
-func (p *CrossEncoderPipeline) Forward(batch *backends.PipelineBatch) error {
+func (p *CrossEncoderPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
 	if p.Model.Tokenizer.MaxAllowedTokens >= p.Model.MaxPositionEmbeddings {
 		p.Model.Tokenizer.MaxAllowedTokens = p.Model.MaxPositionEmbeddings - 1
 	}
-	err := backends.RunSessionOnBatch(batch, p.BasePipeline)
+	err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline)
 	if err != nil {
 		return err
 	}
@@ -189,7 +190,7 @@ func (p *CrossEncoderPipeline) Forward(batch *backends.PipelineBatch) error {
 	return nil
 }
 
-func (p *CrossEncoderPipeline) Postprocess(batch *backends.PipelineBatch, documents []string) (*CrossEncoderOutput, error) {
+func (p *CrossEncoderPipeline) postprocess(batch *backends.PipelineBatch, documents []string) (*CrossEncoderOutput, error) {
 	var outputCast [][]float32
 	output := batch.OutputValues[0]
 	switch v := output.(type) {
@@ -219,16 +220,16 @@ func (p *CrossEncoderPipeline) Postprocess(batch *backends.PipelineBatch, docume
 	return &CrossEncoderOutput{Results: results}, nil
 }
 
-func (p *CrossEncoderPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
+func (p *CrossEncoderPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
 	if len(inputs) < 2 {
 		return nil, errors.New("cross encoder pipeline requires at least two inputs: a query and one or more documents")
 	}
 	query := inputs[0]
 	documents := inputs[1:]
-	return p.RunPipeline(query, documents)
+	return p.RunPipeline(ctx, query, documents)
 }
 
-func (p *CrossEncoderPipeline) RunPipeline(query string, documents []string) (*CrossEncoderOutput, error) {
+func (p *CrossEncoderPipeline) RunPipeline(ctx context.Context, query string, documents []string) (*CrossEncoderOutput, error) {
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -240,7 +241,7 @@ func (p *CrossEncoderPipeline) RunPipeline(query string, documents []string) (*C
 	allResults := make([]CrossEncoderResult, 0, len(documents))
 	for i := 0; i < len(documents); i += p.batchSize {
 		end := min(i+p.batchSize, len(documents))
-		out, err := p.runBatch(query, documents[i:end], i)
+		out, err := p.runBatch(ctx, query, documents[i:end], i)
 		if err != nil {
 			runErrors = append(runErrors, err)
 			continue
@@ -261,7 +262,7 @@ func (p *CrossEncoderPipeline) RunPipeline(query string, documents []string) (*C
 	return output, errors.Join(runErrors...)
 }
 
-func (p *CrossEncoderPipeline) runBatch(query string, documents []string, startIndex int) (*CrossEncoderOutput, error) {
+func (p *CrossEncoderPipeline) runBatch(ctx context.Context, query string, documents []string, startIndex int) (*CrossEncoderOutput, error) {
 	var runErrors []error
 	inputs := make([][2]string, len(documents))
 	for i, doc := range documents {
@@ -271,15 +272,15 @@ func (p *CrossEncoderPipeline) runBatch(query string, documents []string, startI
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
-	runErrors = append(runErrors, p.PreprocessPairs(batch, inputs))
+	runErrors = append(runErrors, p.preprocessPairs(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch, documents)
+	result, postErr := p.postprocess(batch, documents)
 	runErrors = append(runErrors, postErr)
 	if result != nil {
 		for i := range result.Results {

--- a/pipelines/featureExtraction.go
+++ b/pipelines/featureExtraction.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -84,8 +85,8 @@ func WithImageMode() backends.PipelineOption[*FeatureExtractionPipeline] {
 }
 
 // NewFeatureExtractionPipeline init a feature extraction pipeline.
-func NewFeatureExtractionPipeline(config backends.PipelineConfig[*FeatureExtractionPipeline], s *options.Options, model *backends.Model) (*FeatureExtractionPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewFeatureExtractionPipeline(sessionContext context.Context, config backends.PipelineConfig[*FeatureExtractionPipeline], s *options.Options, model *backends.Model) (*FeatureExtractionPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -195,8 +196,8 @@ func (p *FeatureExtractionPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-// Preprocess tokenizes the input strings.
-func (p *FeatureExtractionPipeline) Preprocess(batch *backends.PipelineBatch, inputs []string) error {
+// preprocess tokenizes the input strings.
+func (p *FeatureExtractionPipeline) preprocess(batch *backends.PipelineBatch, inputs []string) error {
 	start := time.Now()
 	backends.TokenizeInputs(batch, p.Model.Tokenizer, inputs)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -205,10 +206,10 @@ func (p *FeatureExtractionPipeline) Preprocess(batch *backends.PipelineBatch, in
 	return err
 }
 
-// Forward performs the forward inference of the feature extraction pipeline.
-func (p *FeatureExtractionPipeline) Forward(batch *backends.PipelineBatch) error {
+// forward performs the forward inference of the feature extraction pipeline.
+func (p *FeatureExtractionPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	err := backends.RunSessionOnBatch(batch, p.BasePipeline)
+	err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline)
 	if err != nil {
 		return err
 	}
@@ -217,8 +218,8 @@ func (p *FeatureExtractionPipeline) Forward(batch *backends.PipelineBatch) error
 	return nil
 }
 
-// Postprocess parses the first output from the network similar to the transformers' implementation.
-func (p *FeatureExtractionPipeline) Postprocess(batch *backends.PipelineBatch) (*FeatureExtractionOutput, error) {
+// postprocess parses the first output from the network similar to the transformers' implementation.
+func (p *FeatureExtractionPipeline) postprocess(batch *backends.PipelineBatch) (*FeatureExtractionOutput, error) {
 	// TODO: this works if token embeddings are returned or sentence embeddings are returned.
 	// in the former case embeddings are mean pooled. In the latter they are just returned.
 	// to make this more general for other pipelines and to allow return of raw token embeddings,
@@ -280,26 +281,26 @@ func meanPooling(tokens [][]float32, input backends.TokenizedInput, maxSequence 
 }
 
 // Run the pipeline on a batch of strings.
-func (p *FeatureExtractionPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *FeatureExtractionPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
 // RunPipeline is like Run, but returns the concrete feature extraction output type rather than the interface.
-func (p *FeatureExtractionPipeline) RunPipeline(inputs []string) (*FeatureExtractionOutput, error) {
+func (p *FeatureExtractionPipeline) RunPipeline(ctx context.Context, inputs []string) (*FeatureExtractionOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }
@@ -317,7 +318,7 @@ func (p *FeatureExtractionPipeline) PreprocessImages(batch *backends.PipelineBat
 
 // RunWithImages runs the pipeline on a batch of images (for vision models).
 // Use this method when ImageMode is enabled.
-func (p *FeatureExtractionPipeline) RunWithImages(images []image.Image) (*FeatureExtractionOutput, error) {
+func (p *FeatureExtractionPipeline) RunWithImages(ctx context.Context, images []image.Image) (*FeatureExtractionOutput, error) {
 	if !p.imageMode {
 		return nil, fmt.Errorf("RunWithImages requires ImageMode to be enabled; use WithImageMode() option")
 	}
@@ -330,21 +331,21 @@ func (p *FeatureExtractionPipeline) RunWithImages(images []image.Image) (*Featur
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }
 
 // RunWithImagePaths loads images from file paths and runs the pipeline.
 // Convenience method that combines image loading with RunWithImages.
-func (p *FeatureExtractionPipeline) RunWithImagePaths(paths []string) (*FeatureExtractionOutput, error) {
+func (p *FeatureExtractionPipeline) RunWithImagePaths(ctx context.Context, paths []string) (*FeatureExtractionOutput, error) {
 	images, err := imageutil.LoadImagesFromPaths(paths)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load images: %w", err)
 	}
-	return p.RunWithImages(images)
+	return p.RunWithImages(ctx, images)
 }

--- a/pipelines/featureExtraction_image_test.go
+++ b/pipelines/featureExtraction_image_test.go
@@ -123,7 +123,7 @@ func TestImageModeValidation(t *testing.T) {
 	}
 
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
-	_, err := pipeline.RunWithImages([]image.Image{img})
+	_, err := pipeline.RunWithImages(t.Context(), []image.Image{img})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "ImageMode")
 }

--- a/pipelines/imageClassification.go
+++ b/pipelines/imageClassification.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -69,8 +70,8 @@ func WithTopK(topK int) backends.PipelineOption[*ImageClassificationPipeline] {
 }
 
 // NewImageClassificationPipeline initializes an image classification pipeline.
-func NewImageClassificationPipeline(config backends.PipelineConfig[*ImageClassificationPipeline], s *options.Options, model *backends.Model) (*ImageClassificationPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewImageClassificationPipeline(sessionContext context.Context, config backends.PipelineConfig[*ImageClassificationPipeline], s *options.Options, model *backends.Model) (*ImageClassificationPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -131,9 +132,9 @@ func (p *ImageClassificationPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-// Preprocess decodes images from file paths or image.Image and creates input tensors.
-// Preprocess loads images from file paths and creates input tensors.
-func (p *ImageClassificationPipeline) Preprocess(batch *backends.PipelineBatch, inputs []image.Image) error {
+// preprocess decodes images from file paths or image.Image and creates input tensors.
+// preprocess loads images from file paths and creates input tensors.
+func (p *ImageClassificationPipeline) preprocess(batch *backends.PipelineBatch, inputs []image.Image) error {
 	preprocessed, err := backends.PreprocessImages(p.imageFormat, inputs, p.preprocessSteps, p.normalizationSteps)
 	if err != nil {
 		return fmt.Errorf("failed to preprocess images: %w", err)
@@ -141,10 +142,10 @@ func (p *ImageClassificationPipeline) Preprocess(batch *backends.PipelineBatch, 
 	return backends.CreateImageTensors(batch, p.Model, preprocessed, p.Runtime)
 }
 
-// Forward runs inference.
-func (p *ImageClassificationPipeline) Forward(batch *backends.PipelineBatch) error {
+// forward runs inference.
+func (p *ImageClassificationPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	if err := backends.RunSessionOnBatch(batch, p.BasePipeline); err != nil {
+	if err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline); err != nil {
 		return err
 	}
 	atomic.AddUint64(&p.PipelineTimings.NumCalls, 1)
@@ -152,8 +153,8 @@ func (p *ImageClassificationPipeline) Forward(batch *backends.PipelineBatch) err
 	return nil
 }
 
-// Postprocess parses logits and returns top-k predictions for each image.
-func (p *ImageClassificationPipeline) Postprocess(batch *backends.PipelineBatch) (*ImageClassificationOutput, error) {
+// postprocess parses logits and returns top-k predictions for each image.
+func (p *ImageClassificationPipeline) postprocess(batch *backends.PipelineBatch) (*ImageClassificationOutput, error) {
 	output := batch.OutputValues[0]
 	var batchPreds [][]ImageClassificationResult
 	logits, ok := output.([][]float32)
@@ -198,12 +199,12 @@ func getTopK(logits []float32, k int, labels map[int]string) []ImageClassificati
 }
 
 // Run runs the pipeline on a batch of image file paths.
-func (p *ImageClassificationPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *ImageClassificationPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
 // RunPipeline returns the concrete output type.
-func (p *ImageClassificationPipeline) RunPipeline(inputs []string) (*ImageClassificationOutput, error) {
+func (p *ImageClassificationPipeline) RunPipeline(ctx context.Context, inputs []string) (*ImageClassificationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
@@ -213,34 +214,34 @@ func (p *ImageClassificationPipeline) RunPipeline(inputs []string) (*ImageClassi
 	if err != nil {
 		return nil, fmt.Errorf("failed to load images: %w", err)
 	}
-	runErrors = append(runErrors, p.Preprocess(batch, images))
+	runErrors = append(runErrors, p.preprocess(batch, images))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }
 
-func (p *ImageClassificationPipeline) RunWithImages(inputs []image.Image) (*ImageClassificationOutput, error) {
+func (p *ImageClassificationPipeline) RunWithImages(ctx context.Context, inputs []image.Image) (*ImageClassificationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }

--- a/pipelines/objectDetection.go
+++ b/pipelines/objectDetection.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -21,23 +22,23 @@ import (
 // It supports models that output bounding boxes and class scores.
 type ObjectDetectionPipeline struct {
 	*backends.BasePipeline
-	IDLabelMap     map[int]string
-	imageFormat    string
-	BoxesOutput    string
-	ScoresOutput   string
-	preprocess     []imageutil.PreprocessStep
-	normalize      []imageutil.NormalizationStep
-	TopK           int
-	ScoreThreshold float32
-	IouThreshold   float32
+	IDLabelMap      map[int]string
+	imageFormat     string
+	BoxesOutput     string
+	ScoresOutput    string
+	preprocessSteps []imageutil.PreprocessStep
+	normalizeSteps  []imageutil.NormalizationStep
+	TopK            int
+	ScoreThreshold  float32
+	IouThreshold    float32
 }
 
 func (p *ObjectDetectionPipeline) addPreprocessSteps(steps ...imageutil.PreprocessStep) {
-	p.preprocess = append(p.preprocess, steps...)
+	p.preprocessSteps = append(p.preprocessSteps, steps...)
 }
 
 func (p *ObjectDetectionPipeline) addNormalizationSteps(steps ...imageutil.NormalizationStep) {
-	p.normalize = append(p.normalize, steps...)
+	p.normalizeSteps = append(p.normalizeSteps, steps...)
 }
 
 func (p *ObjectDetectionPipeline) setImageFormat(format string) {
@@ -90,8 +91,8 @@ func WithDetectionTopK(k int) backends.PipelineOption[*ObjectDetectionPipeline] 
 }
 
 // NewObjectDetectionPipeline initializes an object detection pipeline.
-func NewObjectDetectionPipeline(config backends.PipelineConfig[*ObjectDetectionPipeline], s *options.Options, model *backends.Model) (*ObjectDetectionPipeline, error) {
-	base, err := backends.NewBasePipeline(config, s, model)
+func NewObjectDetectionPipeline(sessionContext context.Context, config backends.PipelineConfig[*ObjectDetectionPipeline], s *options.Options, model *backends.Model) (*ObjectDetectionPipeline, error) {
+	base, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +111,8 @@ func NewObjectDetectionPipeline(config backends.PipelineConfig[*ObjectDetectionP
 		p.imageFormat = fmtDetected
 	}
 	// Set sensible default normalization for vision models (Rescale + ImageNet mean/std)
-	if len(p.normalize) == 0 {
-		p.normalize = []imageutil.NormalizationStep{
+	if len(p.normalizeSteps) == 0 {
+		p.normalizeSteps = []imageutil.NormalizationStep{
 			imageutil.RescaleStep(),
 			imageutil.ImagenetPixelNormalizationStep(),
 		}
@@ -179,19 +180,19 @@ func (p *ObjectDetectionPipeline) Validate() error {
 	return errors.Join(errs...)
 }
 
-// Preprocess images into tensors.
-func (p *ObjectDetectionPipeline) Preprocess(batch *backends.PipelineBatch, inputs []image.Image) error {
-	processed, err := backends.PreprocessImages(p.imageFormat, inputs, p.preprocess, p.normalize)
+// preprocess images into tensors.
+func (p *ObjectDetectionPipeline) preprocess(batch *backends.PipelineBatch, inputs []image.Image) error {
+	processed, err := backends.PreprocessImages(p.imageFormat, inputs, p.preprocessSteps, p.normalizeSteps)
 	if err != nil {
 		return err
 	}
 	return backends.CreateImageTensors(batch, p.Model, processed, p.Runtime)
 }
 
-// Forward inference.
-func (p *ObjectDetectionPipeline) Forward(batch *backends.PipelineBatch) error {
+// forward inference.
+func (p *ObjectDetectionPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	if err := backends.RunSessionOnBatch(batch, p.BasePipeline); err != nil {
+	if err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline); err != nil {
 		return err
 	}
 	atomic.AddUint64(&p.PipelineTimings.NumCalls, 1)
@@ -199,8 +200,8 @@ func (p *ObjectDetectionPipeline) Forward(batch *backends.PipelineBatch) error {
 	return nil
 }
 
-// Postprocess parses boxes/scores, applies thresholds and NMS.
-func (p *ObjectDetectionPipeline) Postprocess(batch *backends.PipelineBatch) (*ObjectDetectionOutput, error) {
+// postprocess parses boxes/scores, applies thresholds and NMS.
+func (p *ObjectDetectionPipeline) postprocess(batch *backends.PipelineBatch) (*ObjectDetectionOutput, error) {
 	// Locate outputs by name in OutputValues
 	// We assume order of Model.OutputsMeta corresponds to OutputValues
 	boxesIdx, scoresIdx := -1, -1
@@ -329,11 +330,11 @@ func nonMaxSuppress(dets []Detection, iouTh float32) []Detection {
 }
 
 // Run with file paths.
-func (p *ObjectDetectionPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *ObjectDetectionPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
-func (p *ObjectDetectionPipeline) RunPipeline(inputs []string) (*ObjectDetectionOutput, error) {
+func (p *ObjectDetectionPipeline) RunPipeline(ctx context.Context, inputs []string) (*ObjectDetectionOutput, error) {
 	var errs []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) { errs = append(errs, batch.Destroy()) }(batch)
@@ -341,32 +342,32 @@ func (p *ObjectDetectionPipeline) RunPipeline(inputs []string) (*ObjectDetection
 	if err != nil {
 		return nil, fmt.Errorf("failed to load images: %w", err)
 	}
-	errs = append(errs, p.Preprocess(batch, imgs))
+	errs = append(errs, p.preprocess(batch, imgs))
 	if e := errors.Join(errs...); e != nil {
 		return nil, e
 	}
-	errs = append(errs, p.Forward(batch))
+	errs = append(errs, p.forward(ctx, batch))
 	if e := errors.Join(errs...); e != nil {
 		return nil, e
 	}
-	res, postErr := p.Postprocess(batch)
+	res, postErr := p.postprocess(batch)
 	errs = append(errs, postErr)
 	return res, errors.Join(errs...)
 }
 
-func (p *ObjectDetectionPipeline) RunWithImages(inputs []image.Image) (*ObjectDetectionOutput, error) {
+func (p *ObjectDetectionPipeline) RunWithImages(ctx context.Context, inputs []image.Image) (*ObjectDetectionOutput, error) {
 	var errs []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) { errs = append(errs, batch.Destroy()) }(batch)
-	errs = append(errs, p.Preprocess(batch, inputs))
+	errs = append(errs, p.preprocess(batch, inputs))
 	if e := errors.Join(errs...); e != nil {
 		return nil, e
 	}
-	errs = append(errs, p.Forward(batch))
+	errs = append(errs, p.forward(ctx, batch))
 	if e := errors.Join(errs...); e != nil {
 		return nil, e
 	}
-	res, postErr := p.Postprocess(batch)
+	res, postErr := p.postprocess(batch)
 	errs = append(errs, postErr)
 	return res, errors.Join(errs...)
 }

--- a/pipelines/questionAnswering.go
+++ b/pipelines/questionAnswering.go
@@ -15,6 +15,7 @@ package pipelines
 // Typical models: distilbert-base-uncased-distilled-squad, bert-large-uncased-whole-word-masking-finetuned-squad.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -90,8 +91,8 @@ func WithTopKAnswers(k int) backends.PipelineOption[*QuestionAnsweringPipeline] 
 }
 
 // NewQuestionAnsweringPipeline initialises a question answering pipeline.
-func NewQuestionAnsweringPipeline(config backends.PipelineConfig[*QuestionAnsweringPipeline], s *options.Options, model *backends.Model) (*QuestionAnsweringPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewQuestionAnsweringPipeline(sessionContext context.Context, config backends.PipelineConfig[*QuestionAnsweringPipeline], s *options.Options, model *backends.Model) (*QuestionAnsweringPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -174,8 +175,8 @@ func (p *QuestionAnsweringPipeline) Validate() error {
 	return errors.Join(errs...)
 }
 
-// Preprocess tokenises each question/context pair into a single combined sequence.
-func (p *QuestionAnsweringPipeline) Preprocess(batch *backends.PipelineBatch, inputs []QuestionAnsweringInput) error {
+// preprocess tokenises each question/context pair into a single combined sequence.
+func (p *QuestionAnsweringPipeline) preprocess(batch *backends.PipelineBatch, inputs []QuestionAnsweringInput) error {
 	start := time.Now()
 	inputPairs := make([][2]string, 0, len(inputs))
 	for _, in := range inputs {
@@ -188,10 +189,10 @@ func (p *QuestionAnsweringPipeline) Preprocess(batch *backends.PipelineBatch, in
 	return err
 }
 
-// Forward runs the ONNX session on the batch.
-func (p *QuestionAnsweringPipeline) Forward(batch *backends.PipelineBatch) error {
+// forward runs the ONNX session on the batch.
+func (p *QuestionAnsweringPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	if err := backends.RunSessionOnBatch(batch, p.BasePipeline); err != nil {
+	if err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline); err != nil {
 		return err
 	}
 	atomic.AddUint64(&p.PipelineTimings.NumCalls, 1)
@@ -199,8 +200,8 @@ func (p *QuestionAnsweringPipeline) Forward(batch *backends.PipelineBatch) error
 	return nil
 }
 
-// Postprocess extracts the top-k answer spans for each item in the batch, ranked by score descending.
-func (p *QuestionAnsweringPipeline) Postprocess(batch *backends.PipelineBatch, inputs []QuestionAnsweringInput) (*QuestionAnsweringBatchOutput, error) {
+// postprocess extracts the top-k answer spans for each item in the batch, ranked by score descending.
+func (p *QuestionAnsweringPipeline) postprocess(batch *backends.PipelineBatch, inputs []QuestionAnsweringInput) (*QuestionAnsweringBatchOutput, error) {
 	if len(batch.OutputValues) < 2 {
 		return nil, fmt.Errorf("expected at least 2 output tensors (start_logits, end_logits), got %d", len(batch.OutputValues))
 	}
@@ -240,7 +241,7 @@ func (p *QuestionAnsweringPipeline) Postprocess(batch *backends.PipelineBatch, i
 }
 
 // Run implements the Pipeline interface. Inputs are interleaved [question0, context0, question1, context1, …].
-func (p *QuestionAnsweringPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
+func (p *QuestionAnsweringPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
 	if len(inputs) == 0 || len(inputs)%2 != 0 {
 		return nil, fmt.Errorf("question answering pipeline requires an even, non-zero number of strings: [question0, context0, question1, context1, ...]")
 	}
@@ -248,28 +249,28 @@ func (p *QuestionAnsweringPipeline) Run(inputs []string) (backends.PipelineBatch
 	for i := 0; i < len(inputs); i += 2 {
 		qaInputs[i/2] = QuestionAnsweringInput{Question: inputs[i], Context: inputs[i+1]}
 	}
-	return p.RunPipeline(qaInputs)
+	return p.RunPipeline(ctx, qaInputs)
 }
 
 // RunPipeline is the typed entry point for the question answering pipeline.
-func (p *QuestionAnsweringPipeline) RunPipeline(inputs []QuestionAnsweringInput) (*QuestionAnsweringBatchOutput, error) {
+func (p *QuestionAnsweringPipeline) RunPipeline(ctx context.Context, inputs []QuestionAnsweringInput) (*QuestionAnsweringBatchOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
 
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	result, postErr := p.Postprocess(batch, inputs)
+	result, postErr := p.postprocess(batch, inputs)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }

--- a/pipelines/tabular.go
+++ b/pipelines/tabular.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -94,8 +95,8 @@ func WithIDLabelMap(labels map[int]string) backends.PipelineOption[*TabularPipel
 }
 
 // NewTabularPipeline initializes the pipeline.
-func NewTabularPipeline(config backends.PipelineConfig[*TabularPipeline], s *options.Options, model *backends.Model) (*TabularPipeline, error) {
-	base, err := backends.NewBasePipeline(config, s, model)
+func NewTabularPipeline(sessionContext context.Context, config backends.PipelineConfig[*TabularPipeline], s *options.Options, model *backends.Model) (*TabularPipeline, error) {
+	base, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +209,8 @@ func (p *TabularPipeline) Validate() error {
 	return errors.Join(errs...)
 }
 
-// Preprocess parses inputs strings into [][]float32 and builds tensors.
-func (p *TabularPipeline) Preprocess(batch *backends.PipelineBatch, inputs [][]float32) error {
+// preprocess parses inputs strings into [][]float32 and builds tensors.
+func (p *TabularPipeline) preprocess(batch *backends.PipelineBatch, inputs [][]float32) error {
 	start := time.Now()
 	// Build tensors
 	if err := backends.CreateTabularTensors(batch, p.Model, inputs, p.Runtime); err != nil {
@@ -219,9 +220,9 @@ func (p *TabularPipeline) Preprocess(batch *backends.PipelineBatch, inputs [][]f
 	return nil
 }
 
-func (p *TabularPipeline) Forward(batch *backends.PipelineBatch) error {
+func (p *TabularPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	if err := backends.RunSessionOnBatch(batch, p.BasePipeline); err != nil {
+	if err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline); err != nil {
 		return err
 	}
 	atomic.AddUint64(&p.PipelineTimings.NumCalls, 1)
@@ -229,7 +230,7 @@ func (p *TabularPipeline) Forward(batch *backends.PipelineBatch) error {
 	return nil
 }
 
-func (p *TabularPipeline) Postprocess(batch *backends.PipelineBatch) (*TabularOutput, error) {
+func (p *TabularPipeline) postprocess(batch *backends.PipelineBatch) (*TabularOutput, error) {
 	if p.ProblemType == "classification" {
 		results := make([]TabularClassificationOutput, batch.Size)
 		var agg func([]float32) []float32
@@ -320,32 +321,32 @@ func (p *TabularPipeline) Postprocess(batch *backends.PipelineBatch) (*TabularOu
 }
 
 // Run executes the pipeline over inputs.
-func (p *TabularPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
+func (p *TabularPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
 	features, err := parseFeatures(inputs)
 	if err != nil {
 		return nil, err
 	}
-	return p.RunPipeline(features)
+	return p.RunPipeline(ctx, features)
 }
 
-func (p *TabularPipeline) RunPipeline(inputs [][]float32) (*TabularOutput, error) {
+func (p *TabularPipeline) RunPipeline(ctx context.Context, inputs [][]float32) (*TabularOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
 
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }

--- a/pipelines/textClassification.go
+++ b/pipelines/textClassification.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -71,8 +72,8 @@ func WithFixedPadding(fixedPaddingLength int) backends.PipelineOption[*TextClass
 }
 
 // NewTextClassificationPipeline initializes a new text classification pipeline.
-func NewTextClassificationPipeline(config backends.PipelineConfig[*TextClassificationPipeline], s *options.Options, model *backends.Model) (*TextClassificationPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewTextClassificationPipeline(sessionContext context.Context, config backends.PipelineConfig[*TextClassificationPipeline], s *options.Options, model *backends.Model) (*TextClassificationPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -168,8 +169,8 @@ func (p *TextClassificationPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-// Preprocess tokenizes the input strings.
-func (p *TextClassificationPipeline) Preprocess(batch *backends.PipelineBatch, inputs []string) error {
+// preprocess tokenizes the input strings.
+func (p *TextClassificationPipeline) preprocess(batch *backends.PipelineBatch, inputs []string) error {
 	start := time.Now()
 	backends.TokenizeInputs(batch, p.Model.Tokenizer, inputs)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -183,9 +184,9 @@ func (p *TextClassificationPipeline) Preprocess(batch *backends.PipelineBatch, i
 	return err
 }
 
-func (p *TextClassificationPipeline) Forward(batch *backends.PipelineBatch) error {
+func (p *TextClassificationPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	err := backends.RunSessionOnBatch(batch, p.BasePipeline)
+	err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline)
 	if err != nil {
 		return err
 	}
@@ -194,7 +195,7 @@ func (p *TextClassificationPipeline) Forward(batch *backends.PipelineBatch) erro
 	return nil
 }
 
-func (p *TextClassificationPipeline) Postprocess(batch *backends.PipelineBatch) (*TextClassificationOutput, error) {
+func (p *TextClassificationPipeline) postprocess(batch *backends.PipelineBatch) (*TextClassificationOutput, error) {
 	var aggregationFunction func([]float32) []float32
 	switch p.AggregationFunctionName {
 	case "SIGMOID":
@@ -262,28 +263,28 @@ func (p *TextClassificationPipeline) Postprocess(batch *backends.PipelineBatch) 
 }
 
 // Run the pipeline on a string batch.
-func (p *TextClassificationPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *TextClassificationPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
-func (p *TextClassificationPipeline) RunPipeline(inputs []string) (*TextClassificationOutput, error) {
+func (p *TextClassificationPipeline) RunPipeline(ctx context.Context, inputs []string) (*TextClassificationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
 
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
 
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }

--- a/pipelines/textGeneration.go
+++ b/pipelines/textGeneration.go
@@ -109,8 +109,8 @@ func WithGuidance(guidance *backends.Guidance) backends.PipelineOption[*TextGene
 }
 
 // NewTextGenerationPipeline initializes a new text generation pipeline.
-func NewTextGenerationPipeline(config backends.PipelineConfig[*TextGenerationPipeline], s *options.Options, model *backends.Model) (*TextGenerationPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewTextGenerationPipeline(sessionContext context.Context, config backends.PipelineConfig[*TextGenerationPipeline], s *options.Options, model *backends.Model) (*TextGenerationPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -171,12 +171,12 @@ func (p *TextGenerationPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-func (p *TextGenerationPipeline) Preprocess(batch *backends.PipelineBatch, inputs any) error {
+func (p *TextGenerationPipeline) preprocess(batch *backends.PipelineBatch, inputs any) error {
 	return backends.CreateMessages(batch, p.BasePipeline, inputs, p.SystemPrompt)
 }
 
-// forwardWith initiates the generation loop with explicit tools and guidance, allowing per-call overrides.
-func (p *TextGenerationPipeline) Forward(ctx context.Context, batch *backends.PipelineBatch, tools []string, guidance *backends.Guidance) (chan backends.SequenceDelta, chan error, error) {
+// forward initiates the generation loop with explicit tools and guidance, allowing per-call overrides.
+func (p *TextGenerationPipeline) forward(ctx context.Context, batch *backends.PipelineBatch, tools []string, guidance *backends.Guidance) (chan backends.SequenceDelta, chan error, error) {
 	effectiveTools := tools
 	if len(effectiveTools) == 0 {
 		effectiveTools = p.Tools
@@ -192,20 +192,19 @@ func (p *TextGenerationPipeline) Forward(ctx context.Context, batch *backends.Pi
 	return tokenStream, errorStream, nil
 }
 
-func (p *TextGenerationPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(context.Background(), inputs)
+func (p *TextGenerationPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
-// RunPipeline processes a batch of string inputs.
 func (p *TextGenerationPipeline) RunPipeline(ctx context.Context, inputs []string) (*TextGenerationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	batch.MaxNewTokens = p.MaxLength
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, errors.Join(e, batch.Destroy())
 	}
-	tokenStream, errorStream, forwardErr := p.Forward(ctx, batch, p.Tools, p.Guidance)
+	tokenStream, errorStream, forwardErr := p.forward(ctx, batch, p.Tools, p.Guidance)
 	if forwardErr != nil {
 		return nil, errors.Join(forwardErr, batch.Destroy())
 	}
@@ -233,11 +232,11 @@ func (p *TextGenerationPipeline) runMessages(ctx context.Context, inputs [][]bac
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	batch.MaxNewTokens = p.MaxLength
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, errors.Join(e, batch.Destroy())
 	}
-	tokenStream, errorStream, forwardErr := p.Forward(ctx, batch, tools, guidance)
+	tokenStream, errorStream, forwardErr := p.forward(ctx, batch, tools, guidance)
 	if forwardErr != nil {
 		return nil, errors.Join(forwardErr, batch.Destroy())
 	}

--- a/pipelines/tokenClassification.go
+++ b/pipelines/tokenClassification.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -108,8 +109,8 @@ func WithSplitWords() backends.PipelineOption[*TokenClassificationPipeline] {
 }
 
 // NewTokenClassificationPipeline Initializes a feature extraction pipeline.
-func NewTokenClassificationPipeline(config backends.PipelineConfig[*TokenClassificationPipeline], s *options.Options, model *backends.Model) (*TokenClassificationPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewTokenClassificationPipeline(sessionContext context.Context, config backends.PipelineConfig[*TokenClassificationPipeline], s *options.Options, model *backends.Model) (*TokenClassificationPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +194,8 @@ func (p *TokenClassificationPipeline) Validate() error {
 	return errors.Join(validationErrors...)
 }
 
-// Preprocess tokenizes the input strings.
-func (p *TokenClassificationPipeline) Preprocess(batch *backends.PipelineBatch, inputs []string) error {
+// preprocess tokenizes the input strings.
+func (p *TokenClassificationPipeline) preprocess(batch *backends.PipelineBatch, inputs []string) error {
 	if p.SplitWords {
 		return fmt.Errorf("split-words enabled: use RunWords/PreprocessWords for [][]string inputs")
 	}
@@ -206,8 +207,8 @@ func (p *TokenClassificationPipeline) Preprocess(batch *backends.PipelineBatch, 
 	return err
 }
 
-// PreprocessWords tokenizes pre-split words and maps tokens to word IDs via offsets.
-func (p *TokenClassificationPipeline) PreprocessWords(batch *backends.PipelineBatch, inputs [][]string) error {
+// preprocessWords tokenizes pre-split words and maps tokens to word IDs via offsets.
+func (p *TokenClassificationPipeline) preprocessWords(batch *backends.PipelineBatch, inputs [][]string) error {
 	start := time.Now()
 	// Join words with single spaces to simulate pretokenized behavior
 	joined := make([]string, len(inputs))
@@ -256,10 +257,10 @@ func (p *TokenClassificationPipeline) PreprocessWords(batch *backends.PipelineBa
 	return backends.CreateInputTensors(batch, p.Model, p.Runtime)
 }
 
-// Forward performs the forward inference of the pipeline.
-func (p *TokenClassificationPipeline) Forward(batch *backends.PipelineBatch) error {
+// forward performs the forward inference of the pipeline.
+func (p *TokenClassificationPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	err := backends.RunSessionOnBatch(batch, p.BasePipeline)
+	err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline)
 	if err != nil {
 		return err
 	}
@@ -268,8 +269,8 @@ func (p *TokenClassificationPipeline) Forward(batch *backends.PipelineBatch) err
 	return nil
 }
 
-// Postprocess function for a token classification pipeline.
-func (p *TokenClassificationPipeline) Postprocess(batch *backends.PipelineBatch) (*TokenClassificationOutput, error) {
+// postprocess function for a token classification pipeline.
+func (p *TokenClassificationPipeline) postprocess(batch *backends.PipelineBatch) (*TokenClassificationOutput, error) {
 	if batch.Size == 0 {
 		return &TokenClassificationOutput{}, nil
 	}
@@ -292,8 +293,8 @@ func (p *TokenClassificationPipeline) Postprocess(batch *backends.PipelineBatch)
 		Entities: make([][]Entity, batch.Size),
 	}
 	for i, input := range batch.Input {
-		preEntities := p.GatherPreEntities(input, outputCast[i])
-		entities, errAggregate := p.Aggregate(input, preEntities)
+		preEntities := p.gatherPreEntities(input, outputCast[i])
+		entities, errAggregate := p.aggregate(input, preEntities)
 		if errAggregate != nil {
 			return nil, errAggregate
 		}
@@ -309,8 +310,8 @@ func (p *TokenClassificationPipeline) Postprocess(batch *backends.PipelineBatch)
 	return &classificationOutput, nil
 }
 
-// GatherPreEntities from batch of logits to list of pre-aggregated outputs.
-func (p *TokenClassificationPipeline) GatherPreEntities(input backends.TokenizedInput, output [][]float32) []Entity {
+// gatherPreEntities from batch of logits to list of pre-aggregated outputs.
+func (p *TokenClassificationPipeline) gatherPreEntities(input backends.TokenizedInput, output [][]float32) []Entity {
 	sentence := input.Raw
 	var preEntities []Entity
 	for j, tokenScores := range output {
@@ -460,7 +461,7 @@ func (p *TokenClassificationPipeline) aggregateWords(entities []Entity) ([]Entit
 	return wordEntities, nil
 }
 
-func (p *TokenClassificationPipeline) Aggregate(input backends.TokenizedInput, preEntities []Entity) ([]Entity, error) {
+func (p *TokenClassificationPipeline) aggregate(input backends.TokenizedInput, preEntities []Entity) ([]Entity, error) {
 	entities := make([]Entity, len(preEntities))
 	var aggregationError error
 	if p.AggregationStrategy == "SIMPLE" || p.AggregationStrategy == "NONE" {
@@ -492,7 +493,7 @@ func (p *TokenClassificationPipeline) Aggregate(input backends.TokenizedInput, p
 	if p.AggregationStrategy == "NONE" {
 		return entities, nil
 	}
-	return p.GroupEntities(entities)
+	return p.groupEntities(entities)
 }
 
 func (p *TokenClassificationPipeline) getTag(entityName string) (string, string) {
@@ -542,8 +543,8 @@ func (p *TokenClassificationPipeline) groupSubEntities(entities []Entity) (Entit
 	}, nil
 }
 
-// GroupEntities group together adjacent tokens with the same entity predicted.
-func (p *TokenClassificationPipeline) GroupEntities(entities []Entity) ([]Entity, error) {
+// groupEntities group together adjacent tokens with the same entity predicted.
+func (p *TokenClassificationPipeline) groupEntities(entities []Entity) ([]Entity, error) {
 	var entityGroups []Entity
 	var currentGroupDisagg []Entity
 	for _, e := range entities {
@@ -577,26 +578,26 @@ func (p *TokenClassificationPipeline) GroupEntities(entities []Entity) ([]Entity
 }
 
 // Run the pipeline on a string batch.
-func (p *TokenClassificationPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *TokenClassificationPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
 // RunPipeline is like Run but returns the concrete type rather than the interface.
-func (p *TokenClassificationPipeline) RunPipeline(inputs []string) (*TokenClassificationOutput, error) {
+func (p *TokenClassificationPipeline) RunPipeline(ctx context.Context, inputs []string) (*TokenClassificationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
-	runErrors = append(runErrors, p.Preprocess(batch, inputs))
+	runErrors = append(runErrors, p.preprocess(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }
@@ -605,21 +606,21 @@ func (p *TokenClassificationPipeline) RunPipeline(inputs []string) (*TokenClassi
 // Each input is a slice of words representing a pretokenized sentence.
 // This is particularly useful when the user wants to control tokenization because of special tokens,
 // hashtags, or other domain-specific tokenization needs.
-func (p *TokenClassificationPipeline) RunWords(inputs [][]string) (*TokenClassificationOutput, error) {
+func (p *TokenClassificationPipeline) RunWords(ctx context.Context, inputs [][]string) (*TokenClassificationOutput, error) {
 	var runErrors []error
 	batch := backends.NewBatch(len(inputs))
 	defer func(*backends.PipelineBatch) {
 		runErrors = append(runErrors, batch.Destroy())
 	}(batch)
-	runErrors = append(runErrors, p.PreprocessWords(batch, inputs))
+	runErrors = append(runErrors, p.preprocessWords(batch, inputs))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	runErrors = append(runErrors, p.Forward(batch))
+	runErrors = append(runErrors, p.forward(ctx, batch))
 	if e := errors.Join(runErrors...); e != nil {
 		return nil, e
 	}
-	result, postErr := p.Postprocess(batch)
+	result, postErr := p.postprocess(batch)
 	runErrors = append(runErrors, postErr)
 	return result, errors.Join(runErrors...)
 }

--- a/pipelines/zeroShotClassification.go
+++ b/pipelines/zeroShotClassification.go
@@ -1,6 +1,7 @@
 package pipelines
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -102,8 +103,8 @@ func createSequencePairs(sequences interface{}, labels []string, hypothesisTempl
 }
 
 // NewZeroShotClassificationPipeline create new Zero Shot Classification Pipeline.
-func NewZeroShotClassificationPipeline(config backends.PipelineConfig[*ZeroShotClassificationPipeline], s *options.Options, model *backends.Model) (*ZeroShotClassificationPipeline, error) {
-	defaultPipeline, err := backends.NewBasePipeline(config, s, model)
+func NewZeroShotClassificationPipeline(sessionContext context.Context, config backends.PipelineConfig[*ZeroShotClassificationPipeline], s *options.Options, model *backends.Model) (*ZeroShotClassificationPipeline, error) {
+	defaultPipeline, err := backends.NewBasePipeline(sessionContext, config, s, model)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +130,7 @@ func NewZeroShotClassificationPipeline(config backends.PipelineConfig[*ZeroShotC
 	return pipeline, err
 }
 
-func (p *ZeroShotClassificationPipeline) Preprocess(batch *backends.PipelineBatch, inputs []string) error {
+func (p *ZeroShotClassificationPipeline) preprocess(batch *backends.PipelineBatch, inputs []string) error {
 	start := time.Now()
 	backends.TokenizeInputs(batch, p.Model.Tokenizer, inputs)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -138,7 +139,7 @@ func (p *ZeroShotClassificationPipeline) Preprocess(batch *backends.PipelineBatc
 	return err
 }
 
-func (p *ZeroShotClassificationPipeline) PreprocessPairs(batch *backends.PipelineBatch, inputs [][2]string) error {
+func (p *ZeroShotClassificationPipeline) preprocessPairs(batch *backends.PipelineBatch, inputs [][2]string) error {
 	start := time.Now()
 	backends.TokenizeInputPairs(batch, p.Model.Tokenizer, inputs, p.Model.SeparatorToken)
 	atomic.AddUint64(&p.Model.Tokenizer.TokenizerTimings.NumCalls, 1)
@@ -147,9 +148,9 @@ func (p *ZeroShotClassificationPipeline) PreprocessPairs(batch *backends.Pipelin
 	return err
 }
 
-func (p *ZeroShotClassificationPipeline) Forward(batch *backends.PipelineBatch) error {
+func (p *ZeroShotClassificationPipeline) forward(ctx context.Context, batch *backends.PipelineBatch) error {
 	start := time.Now()
-	err := backends.RunSessionOnBatch(batch, p.BasePipeline)
+	err := backends.RunSessionOnBatch(ctx, batch, p.BasePipeline)
 	if err != nil {
 		return err
 	}
@@ -158,7 +159,7 @@ func (p *ZeroShotClassificationPipeline) Forward(batch *backends.PipelineBatch) 
 	return nil
 }
 
-func (p *ZeroShotClassificationPipeline) Postprocess(outputTensors [][][]float32, labels []string, sequences []string) (*ZeroShotOutput, error) {
+func (p *ZeroShotClassificationPipeline) postprocess(outputTensors [][][]float32, labels []string, sequences []string) (*ZeroShotOutput, error) {
 	classificationOutputs := make([]ZeroShotClassificationOutput, 0, len(sequences))
 	LabelLikelihood := make(map[string]float64)
 	if p.Multilabel || len(p.Labels) == 1 {
@@ -263,7 +264,7 @@ func (p *ZeroShotClassificationPipeline) Postprocess(outputTensors [][][]float32
 	}, nil
 }
 
-func (p *ZeroShotClassificationPipeline) RunPipeline(inputs []string) (*ZeroShotOutput, error) {
+func (p *ZeroShotClassificationPipeline) RunPipeline(ctx context.Context, inputs []string) (*ZeroShotOutput, error) {
 	var outputTensors [][][]float32
 	var runErrors []error
 	sequencePairs, _, err := createSequencePairs(inputs, p.Labels, p.HypothesisTemplate)
@@ -274,10 +275,10 @@ func (p *ZeroShotClassificationPipeline) RunPipeline(inputs []string) (*ZeroShot
 		var sequenceTensors [][]float32
 		for _, pair := range sequence {
 			batch := backends.NewBatch(len(inputs))
-			if err := p.PreprocessPairs(batch, [][2]string{{pair[0], pair[1]}}); err != nil {
+			if err := p.preprocessPairs(batch, [][2]string{{pair[0], pair[1]}}); err != nil {
 				return nil, errors.Join(err, batch.Destroy())
 			}
-			if err := p.Forward(batch); err != nil {
+			if err := p.forward(ctx, batch); err != nil {
 				return nil, errors.Join(err, batch.Destroy())
 			}
 			sequenceTensors = append(sequenceTensors, batch.OutputValues[0].([][]float32)[0])
@@ -287,7 +288,7 @@ func (p *ZeroShotClassificationPipeline) RunPipeline(inputs []string) (*ZeroShot
 		}
 		outputTensors = append(outputTensors, sequenceTensors)
 	}
-	outputs, err := p.Postprocess(outputTensors, p.Labels, inputs)
+	outputs, err := p.postprocess(outputTensors, p.Labels, inputs)
 	runErrors = append(runErrors, err)
 	return outputs, errors.Join(runErrors...)
 }
@@ -321,8 +322,8 @@ func (p *ZeroShotClassificationPipeline) GetStatistics() backends.PipelineStatis
 	return statistics
 }
 
-func (p *ZeroShotClassificationPipeline) Run(inputs []string) (backends.PipelineBatchOutput, error) {
-	return p.RunPipeline(inputs)
+func (p *ZeroShotClassificationPipeline) Run(ctx context.Context, inputs []string) (backends.PipelineBatchOutput, error) {
+	return p.RunPipeline(ctx, inputs)
 }
 
 func (p *ZeroShotClassificationPipeline) Validate() error {


### PR DESCRIPTION
This change will make sure that one cannot run a pipeline when the session has been destroyed. It will however not take care of cancelling already running pipelines, as the onnx runtime currently does not support contexts.