### PR TITLE
fix: nil-check model fields in Destroy to prevent double-close panic

### DIFF
--- a/backends/model.go
+++ b/backends/model.go
@@ -74,14 +74,19 @@ func LoadModel(ctx context.Context, path string, onnxFilename string, options *o
 		var destroyErr error
 		if model.Tokenizer != nil {
 			destroyErr = model.Tokenizer.Destroy()
+			model.Tokenizer = nil
 		}
 		switch options.Backend {
 		case "ORT":
-			destroyErr = errors.Join(destroyErr, model.ORTModel.Destroy())
-			model.ORTModel = nil
+			if model.ORTModel != nil {
+				destroyErr = errors.Join(destroyErr, model.ORTModel.Destroy())
+				model.ORTModel = nil
+			}
 		case "GO", "XLA":
-			model.GoMLXModel.Destroy()
-			model.GoMLXModel = nil
+			if model.GoMLXModel != nil {
+				model.GoMLXModel.Destroy()
+				model.GoMLXModel = nil
+			}
 		}
 		return destroyErr
 	}


### PR DESCRIPTION
Fixes #130.

`backends.LoadModel`'s `Destroy` closure called `Tokenizer.Destroy()`, `ORTModel.Destroy()`, and `GoMLXModel.Destroy()` without nil-checking. After the first successful destroy, those fields are set to `nil`; calling `Destroy()` a second time then panics with a nil pointer dereference. The same panic is reachable on partial init, where the closure was assigned but a backend field was never populated.

This guards each call and clears `Tokenizer` for the same double-close reason.