### PR TITLE
chore: Remove minimum patch go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/knights-analytics/hugot
 
-go 1.26.0
+go 1.26
 
 require (
 	github.com/daulet/tokenizers v1.27.0


### PR DESCRIPTION
## Motivation

In order to make hugot friendlier for module importing, we should remove the minimum patch version requirement in the Go version. Since this is pinned at `1.26.0`,  it is functionally equivalent to just using the minor version at `1.26`.

## Changes

- Removes the pinned patch version in `go.mod` from `go 1.26.0` to `go 1.26`